### PR TITLE
Introduce remaining resource schema spec and types

### DIFF
--- a/resource/attribute.go
+++ b/resource/attribute.go
@@ -5,7 +5,27 @@ import "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
 type Attribute struct {
 	Name string `json:"name"`
 
-	Bool *BoolAttribute `json:"bool,omitempty"`
+	Bool         *BoolAttribute         `json:"bool,omitempty"`
+	Float64      *Float64Attribute      `json:"float64,omitempty"`
+	Int64        *Int64Attribute        `json:"int64,omitempty"`
+	List         *ListAttribute         `json:"list,omitempty"`
+	ListNested   *ListNestedAttribute   `json:"list_nested,omitempty"`
+	Map          *MapAttribute          `json:"map,omitempty"`
+	MapNested    *MapNestedAttribute    `json:"map_nested,omitempty"`
+	Number       *NumberAttribute       `json:"number,omitempty"`
+	Object       *ObjectAttribute       `json:"object,omitempty"`
+	Set          *SetAttribute          `json:"set,omitempty"`
+	SetNested    *SetNestedAttribute    `json:"set_nested,omitempty"`
+	SingleNested *SingleNestedAttribute `json:"single_nested,omitempty"`
+	String       *StringAttribute       `json:"string,omitempty"`
+}
+
+type NestedAttributeObject struct {
+	Attributes []Attribute `json:"attributes,omitempty"`
+
+	CustomType    *schema.CustomType          `json:"custom_type,omitempty"`
+	PlanModifiers []schema.ObjectPlanModifier `json:"plan_modifiers,omitempty"`
+	Validators    []schema.ObjectValidator    `json:"validators,omitempty"`
 }
 
 type BoolAttribute struct {
@@ -19,4 +39,164 @@ type BoolAttribute struct {
 	PlanModifiers          []schema.BoolPlanModifier      `json:"plan_modifiers,omitempty"`
 	Sensitive              *bool                          `json:"sensitive,omitempty"`
 	Validators             []schema.BoolValidator         `json:"validators,omitempty"`
+}
+
+type Float64Attribute struct {
+	ComputedOptionalRequired schema.ComputedOptionalRequired `json:"computed_optional_required"`
+
+	AssociatedExternalType *schema.AssociatedExternalType `json:"associated_external_type,omitempty"`
+	CustomType             *schema.CustomType             `json:"custom_type,omitempty"`
+	Default                *schema.Float64Default         `json:"default,omitempty"`
+	DeprecationMessage     *string                        `json:"deprecation_message,omitempty"`
+	Description            *string                        `json:"description,omitempty"`
+	PlanModifiers          []schema.Float64PlanModifier   `json:"plan_modifiers,omitempty"`
+	Sensitive              *bool                          `json:"sensitive,omitempty"`
+	Validators             []schema.Float64Validator      `json:"validators,omitempty"`
+}
+
+type Int64Attribute struct {
+	ComputedOptionalRequired schema.ComputedOptionalRequired `json:"computed_optional_required"`
+
+	AssociatedExternalType *schema.AssociatedExternalType `json:"associated_external_type,omitempty"`
+	CustomType             *schema.CustomType             `json:"custom_type,omitempty"`
+	Default                *schema.Int64Default           `json:"default,omitempty"`
+	DeprecationMessage     *string                        `json:"deprecation_message,omitempty"`
+	Description            *string                        `json:"description,omitempty"`
+	PlanModifiers          []schema.Int64PlanModifier     `json:"plan_modifiers,omitempty"`
+	Sensitive              *bool                          `json:"sensitive,omitempty"`
+	Validators             []schema.Int64Validator        `json:"validators,omitempty"`
+}
+
+type ListAttribute struct {
+	ComputedOptionalRequired schema.ComputedOptionalRequired `json:"computed_optional_required"`
+	ElementType              schema.ElementType              `json:"element_type"`
+
+	AssociatedExternalType *schema.AssociatedExternalType `json:"associated_external_type,omitempty"`
+	CustomType             *schema.CustomType             `json:"custom_type,omitempty"`
+	Default                *schema.ListDefault            `json:"default,omitempty"`
+	DeprecationMessage     *string                        `json:"deprecation_message,omitempty"`
+	Description            *string                        `json:"description,omitempty"`
+	PlanModifiers          []schema.ListPlanModifier      `json:"plan_modifiers,omitempty"`
+	Sensitive              *bool                          `json:"sensitive,omitempty"`
+	Validators             []schema.ListValidator         `json:"validators,omitempty"`
+}
+
+type ListNestedAttribute struct {
+	ComputedOptionalRequired schema.ComputedOptionalRequired `json:"computed_optional_required"`
+	NestedObject             NestedAttributeObject           `json:"nested_object"`
+
+	CustomType         *schema.CustomType        `json:"custom_type,omitempty"`
+	Default            *schema.ListDefault       `json:"default,omitempty"`
+	DeprecationMessage *string                   `json:"deprecation_message,omitempty"`
+	Description        *string                   `json:"description,omitempty"`
+	PlanModifiers      []schema.ListPlanModifier `json:"plan_modifiers,omitempty"`
+	Sensitive          *bool                     `json:"sensitive,omitempty"`
+	Validators         []schema.ListValidator    `json:"validators,omitempty"`
+}
+
+type MapAttribute struct {
+	ComputedOptionalRequired schema.ComputedOptionalRequired `json:"computed_optional_required"`
+	ElementType              schema.ElementType              `json:"element_type"`
+
+	AssociatedExternalType *schema.AssociatedExternalType `json:"associated_external_type,omitempty"`
+	CustomType             *schema.CustomType             `json:"custom_type,omitempty"`
+	Default                *schema.MapDefault             `json:"default,omitempty"`
+	DeprecationMessage     *string                        `json:"deprecation_message,omitempty"`
+	Description            *string                        `json:"description,omitempty"`
+	PlanModifiers          []schema.MapPlanModifier       `json:"plan_modifiers,omitempty"`
+	Sensitive              *bool                          `json:"sensitive,omitempty"`
+	Validators             []schema.MapValidator          `json:"validators,omitempty"`
+}
+
+type MapNestedAttribute struct {
+	ComputedOptionalRequired schema.ComputedOptionalRequired `json:"computed_optional_required"`
+	NestedObject             NestedAttributeObject           `json:"nested_object"`
+
+	CustomType         *schema.CustomType       `json:"custom_type,omitempty"`
+	Default            *schema.MapDefault       `json:"default,omitempty"`
+	DeprecationMessage *string                  `json:"deprecation_message,omitempty"`
+	Description        *string                  `json:"description,omitempty"`
+	PlanModifiers      []schema.MapPlanModifier `json:"plan_modifiers,omitempty"`
+	Sensitive          *bool                    `json:"sensitive,omitempty"`
+	Validators         []schema.MapValidator    `json:"validators,omitempty"`
+}
+
+type NumberAttribute struct {
+	ComputedOptionalRequired schema.ComputedOptionalRequired `json:"computed_optional_required"`
+
+	AssociatedExternalType *schema.AssociatedExternalType `json:"associated_external_type,omitempty"`
+	CustomType             *schema.CustomType             `json:"custom_type,omitempty"`
+	Default                *schema.NumberDefault          `json:"default,omitempty"`
+	DeprecationMessage     *string                        `json:"deprecation_message,omitempty"`
+	Description            *string                        `json:"description,omitempty"`
+	PlanModifiers          []schema.NumberPlanModifier    `json:"plan_modifiers,omitempty"`
+	Sensitive              *bool                          `json:"sensitive,omitempty"`
+	Validators             []schema.NumberValidator       `json:"validators,omitempty"`
+}
+
+type ObjectAttribute struct {
+	AttributeTypes           []schema.ObjectAttributeType    `json:"attribute_types"`
+	ComputedOptionalRequired schema.ComputedOptionalRequired `json:"computed_optional_required"`
+
+	AssociatedExternalType *schema.AssociatedExternalType `json:"associated_external_type,omitempty"`
+	CustomType             *schema.CustomType             `json:"custom_type,omitempty"`
+	Default                *schema.ObjectDefault          `json:"default,omitempty"`
+	DeprecationMessage     *string                        `json:"deprecation_message,omitempty"`
+	Description            *string                        `json:"description,omitempty"`
+	PlanModifiers          []schema.ObjectPlanModifier    `json:"plan_modifiers,omitempty"`
+	Sensitive              *bool                          `json:"sensitive,omitempty"`
+	Validators             []schema.ObjectValidator       `json:"validators,omitempty"`
+}
+
+type SetAttribute struct {
+	ComputedOptionalRequired schema.ComputedOptionalRequired `json:"computed_optional_required"`
+	ElementType              schema.ElementType              `json:"element_type"`
+
+	AssociatedExternalType *schema.AssociatedExternalType `json:"associated_external_type,omitempty"`
+	CustomType             *schema.CustomType             `json:"custom_type,omitempty"`
+	Default                *schema.SetDefault             `json:"default,omitempty"`
+	DeprecationMessage     *string                        `json:"deprecation_message,omitempty"`
+	Description            *string                        `json:"description,omitempty"`
+	PlanModifiers          []schema.SetPlanModifier       `json:"plan_modifiers,omitempty"`
+	Sensitive              *bool                          `json:"sensitive,omitempty"`
+	Validators             []schema.SetValidator          `json:"validators,omitempty"`
+}
+
+type SetNestedAttribute struct {
+	ComputedOptionalRequired schema.ComputedOptionalRequired `json:"computed_optional_required"`
+	NestedObject             NestedAttributeObject           `json:"nested_object"`
+
+	CustomType         *schema.CustomType       `json:"custom_type,omitempty"`
+	Default            *schema.SetDefault       `json:"default,omitempty"`
+	DeprecationMessage *string                  `json:"deprecation_message,omitempty"`
+	Description        *string                  `json:"description,omitempty"`
+	PlanModifiers      []schema.SetPlanModifier `json:"plan_modifiers,omitempty"`
+	Sensitive          *bool                    `json:"sensitive,omitempty"`
+	Validators         []schema.SetValidator    `json:"validators,omitempty"`
+}
+
+type SingleNestedAttribute struct {
+	ComputedOptionalRequired schema.ComputedOptionalRequired `json:"computed_optional_required"`
+	Attributes               []Attribute                     `json:"attributes,omitempty"`
+	AssociatedExternalType   *schema.AssociatedExternalType  `json:"associated_external_type,omitempty"`
+	CustomType               *schema.CustomType              `json:"custom_type,omitempty"`
+	Default                  *schema.ObjectDefault           `json:"default,omitempty"`
+	DeprecationMessage       *string                         `json:"deprecation_message,omitempty"`
+	Description              *string                         `json:"description,omitempty"`
+	PlanModifiers            []schema.ObjectPlanModifier     `json:"plan_modifiers,omitempty"`
+	Sensitive                *bool                           `json:"sensitive,omitempty"`
+	Validators               []schema.ObjectValidator        `json:"validators,omitempty"`
+}
+
+type StringAttribute struct {
+	ComputedOptionalRequired schema.ComputedOptionalRequired `json:"computed_optional_required"`
+
+	AssociatedExternalType *schema.AssociatedExternalType `json:"associated_external_type,omitempty"`
+	CustomType             *schema.CustomType             `json:"custom_type,omitempty"`
+	Default                *schema.StringDefault          `json:"default,omitempty"`
+	DeprecationMessage     *string                        `json:"deprecation_message,omitempty"`
+	Description            *string                        `json:"description,omitempty"`
+	PlanModifiers          []schema.StringPlanModifier    `json:"plan_modifiers,omitempty"`
+	Sensitive              *bool                          `json:"sensitive,omitempty"`
+	Validators             []schema.StringValidator       `json:"validators,omitempty"`
 }

--- a/resource/block.go
+++ b/resource/block.go
@@ -1,5 +1,61 @@
 package resource
 
+import "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
+
 type Block struct {
 	Name string `json:"name"`
+
+	ListNested   *ListNestedBlock   `json:"list_nested,omitempty"`
+	SetNested    *SetNestedBlock    `json:"set_nested,omitempty"`
+	SingleNested *SingleNestedBlock `json:"single_nested,omitempty"`
+}
+
+type NestedBlockObject struct {
+	Attributes []Attribute `json:"attributes,omitempty"`
+	Blocks     []Block     `json:"blocks,omitempty"`
+
+	CustomType    *schema.CustomType          `json:"custom_type,omitempty"`
+	PlanModifiers []schema.ObjectPlanModifier `json:"plan_modifiers,omitempty"`
+	Validators    []schema.ObjectValidator    `json:"validators,omitempty"`
+}
+
+type ListNestedBlock struct {
+	ComputedOptionalRequired schema.ComputedOptionalRequired `json:"computed_optional_required"`
+	NestedObject             NestedBlockObject               `json:"nested_object"`
+
+	CustomType         *schema.CustomType        `json:"custom_type,omitempty"`
+	Default            *schema.ListDefault       `json:"default,omitempty"`
+	DeprecationMessage *string                   `json:"deprecation_message,omitempty"`
+	Description        *string                   `json:"description,omitempty"`
+	PlanModifiers      []schema.ListPlanModifier `json:"plan_modifiers,omitempty"`
+	Sensitive          *bool                     `json:"sensitive,omitempty"`
+	Validators         []schema.ListValidator    `json:"validators,omitempty"`
+}
+
+type SetNestedBlock struct {
+	ComputedOptionalRequired schema.ComputedOptionalRequired `json:"computed_optional_required"`
+	NestedObject             NestedBlockObject               `json:"nested_object"`
+
+	CustomType         *schema.CustomType       `json:"custom_type,omitempty"`
+	Default            *schema.SetDefault       `json:"default,omitempty"`
+	DeprecationMessage *string                  `json:"deprecation_message,omitempty"`
+	Description        *string                  `json:"description,omitempty"`
+	PlanModifiers      []schema.SetPlanModifier `json:"plan_modifiers,omitempty"`
+	Sensitive          *bool                    `json:"sensitive,omitempty"`
+	Validators         []schema.SetValidator    `json:"validators,omitempty"`
+}
+
+type SingleNestedBlock struct {
+	Attributes               []Attribute                     `json:"attributes,omitempty"`
+	Blocks                   []Block                         `json:"blocks,omitempty"`
+	ComputedOptionalRequired schema.ComputedOptionalRequired `json:"computed_optional_required"`
+
+	AssociatedExternalType *schema.AssociatedExternalType `json:"associated_external_type,omitempty"`
+	CustomType             *schema.CustomType             `json:"custom_type,omitempty"`
+	Default                *schema.ObjectDefault          `json:"default,omitempty"`
+	DeprecationMessage     *string                        `json:"deprecation_message,omitempty"`
+	Description            *string                        `json:"description,omitempty"`
+	PlanModifiers          []schema.ObjectPlanModifier    `json:"plan_modifiers,omitempty"`
+	Sensitive              *bool                          `json:"sensitive,omitempty"`
+	Validators             []schema.ObjectValidator       `json:"validators,omitempty"`
 }

--- a/schema/float64_default.go
+++ b/schema/float64_default.go
@@ -1,0 +1,6 @@
+package schema
+
+type Float64Default struct {
+	Custom *CustomDefault `json:"custom,omitempty"`
+	Static *float64       `json:"static,omitempty"`
+}

--- a/schema/float64_plan_modifier.go
+++ b/schema/float64_plan_modifier.go
@@ -1,0 +1,5 @@
+package schema
+
+type Float64PlanModifier struct {
+	Custom *CustomPlanModifier `json:"custom,omitempty"`
+}

--- a/schema/int64_default.go
+++ b/schema/int64_default.go
@@ -1,0 +1,6 @@
+package schema
+
+type Int64Default struct {
+	Custom *CustomDefault `json:"custom,omitempty"`
+	Static *int64         `json:"static,omitempty"`
+}

--- a/schema/int64_plan_modifier.go
+++ b/schema/int64_plan_modifier.go
@@ -1,0 +1,5 @@
+package schema
+
+type Int64PlanModifier struct {
+	Custom *CustomPlanModifier `json:"custom,omitempty"`
+}

--- a/schema/list_default.go
+++ b/schema/list_default.go
@@ -1,0 +1,5 @@
+package schema
+
+type ListDefault struct {
+	Custom *CustomDefault `json:"custom,omitempty"`
+}

--- a/schema/list_plan_modifier.go
+++ b/schema/list_plan_modifier.go
@@ -1,0 +1,5 @@
+package schema
+
+type ListPlanModifier struct {
+	Custom *CustomPlanModifier `json:"custom,omitempty"`
+}

--- a/schema/map_default.go
+++ b/schema/map_default.go
@@ -1,0 +1,5 @@
+package schema
+
+type MapDefault struct {
+	Custom *CustomDefault `json:"custom,omitempty"`
+}

--- a/schema/map_plan_modifier.go
+++ b/schema/map_plan_modifier.go
@@ -1,0 +1,5 @@
+package schema
+
+type MapPlanModifier struct {
+	Custom *CustomPlanModifier `json:"custom,omitempty"`
+}

--- a/schema/number_default.go
+++ b/schema/number_default.go
@@ -1,0 +1,5 @@
+package schema
+
+type NumberDefault struct {
+	Custom *CustomDefault `json:"custom,omitempty"`
+}

--- a/schema/number_plan_modifier.go
+++ b/schema/number_plan_modifier.go
@@ -1,0 +1,5 @@
+package schema
+
+type NumberPlanModifier struct {
+	Custom *CustomPlanModifier `json:"custom,omitempty"`
+}

--- a/schema/object_default.go
+++ b/schema/object_default.go
@@ -1,0 +1,5 @@
+package schema
+
+type ObjectDefault struct {
+	Custom *CustomDefault `json:"custom,omitempty"`
+}

--- a/schema/object_plan_modifier.go
+++ b/schema/object_plan_modifier.go
@@ -1,0 +1,5 @@
+package schema
+
+type ObjectPlanModifier struct {
+	Custom *CustomPlanModifier `json:"custom,omitempty"`
+}

--- a/schema/set_default.go
+++ b/schema/set_default.go
@@ -1,0 +1,5 @@
+package schema
+
+type SetDefault struct {
+	Custom *CustomDefault `json:"custom,omitempty"`
+}

--- a/schema/set_plan_modifier.go
+++ b/schema/set_plan_modifier.go
@@ -1,0 +1,5 @@
+package schema
+
+type SetPlanModifier struct {
+	Custom *CustomPlanModifier `json:"custom,omitempty"`
+}

--- a/schema/string_default.go
+++ b/schema/string_default.go
@@ -1,0 +1,6 @@
+package schema
+
+type StringDefault struct {
+	Custom *CustomDefault `json:"custom,omitempty"`
+	Static *string        `json:"static,omitempty"`
+}

--- a/schema/string_plan_modifier.go
+++ b/schema/string_plan_modifier.go
@@ -1,0 +1,5 @@
+package schema
+
+type StringPlanModifier struct {
+	Custom *CustomPlanModifier `json:"custom,omitempty"`
+}

--- a/spec/example.json
+++ b/spec/example.json
@@ -508,9 +508,6 @@
                 "type": "",
                 "value_type": ""
               },
-              "default": {
-                "static": true
-              },
               "plan_modifiers": [
                 {
                   "requires_replace": {}
@@ -527,6 +524,561 @@
                   "custom": {
                     "import": "github.com/my_account/my_project/myboolvalidator",
                     "schema_definition": "myboolvalidator.Validate()"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "name": "bool_attribute_default_static",
+            "bool": {
+              "computed_optional_required": "optional",
+              "default": {
+                "static": true
+              }
+            }
+          },
+          {
+            "name": "float64_attribute",
+            "float64": {
+              "computed_optional_required": "computed"
+            }
+          },
+          {
+            "name": "float64_attribute_default_static",
+            "float64": {
+              "computed_optional_required": "optional",
+              "default": {
+                "static": 123.45
+              }
+            }
+          },
+          {
+            "name": "int64_attribute",
+            "int64": {
+              "computed_optional_required": "computed"
+            }
+          },
+          {
+            "name": "int64_attribute_default_static",
+            "int64": {
+              "computed_optional_required": "optional",
+              "default": {
+                "static": 123
+              }
+            }
+          },
+          {
+            "name": "list_attribute",
+            "list": {
+              "computed_optional_required": "computed",
+              "element_type": {
+                "string": {}
+              }
+            }
+          },
+          {
+            "name": "list_attribute_default_custom",
+            "list": {
+              "computed_optional_required": "optional",
+              "default": {
+                "custom": {
+                  "import":           "github.com/hashicorp/terraform-plugin-framework/types",
+                  "schema_definition": "types.ListValueMust(types.String, []attr.Value{types.StringValue(\"example\")})"
+                }
+              },
+              "element_type": {
+                "string": {}
+              }
+            }
+          },
+          {
+            "name": "list_map_attribute",
+            "list": {
+              "computed_optional_required": "computed",
+              "element_type": {
+                "map": {
+                  "string": {}
+                }
+              }
+            }
+          },
+          {
+            "name": "list_object_attribute",
+            "list": {
+              "computed_optional_required": "computed",
+              "element_type": {
+                "object": [
+                  {
+                    "name": "obj_string_attr",
+                    "string": {}
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "name": "list_object_object_attribute",
+            "list": {
+              "computed_optional_required": "computed",
+              "element_type": {
+                "object": [
+                  {
+                    "name": "obj_obj_attr",
+                    "object": [
+                      {
+                        "name": "obj_obj_string_attr",
+                        "string": {}
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "name": "map_attribute",
+            "map": {
+              "computed_optional_required": "computed",
+              "element_type": {
+                "string": {}
+              }
+            }
+          },
+          {
+            "name": "map_nested_bool_attribute",
+            "map_nested": {
+              "computed_optional_required": "computed",
+              "nested_object": {
+                "attributes": [
+                  {
+                    "name": "bool_attribute",
+                    "bool": {
+                      "computed_optional_required": "computed"
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "name": "number_attribute",
+            "number": {
+              "computed_optional_required": "computed"
+            }
+          },
+          {
+            "name": "number_attribute_default_custom",
+            "number": {
+              "computed_optional_required": "optional",
+              "default": {
+                "custom": {
+                  "import": "math/big",
+                  "schema_definition": "big.NewFloat(123.45)"
+                }
+              }
+            }
+          },
+          {
+            "name": "object_attribute",
+            "object": {
+              "computed_optional_required": "computed",
+              "attribute_types": [
+                {
+                  "name": "obj_string_attr",
+                  "string": {}
+                }
+              ]
+            }
+          },
+          {
+            "name": "object_list_attribute",
+            "object": {
+              "computed_optional_required": "computed",
+              "attribute_types": [
+                {
+                  "name": "obj_list_attr",
+                  "list": {
+                    "string": {}
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "name": "object_list_object_attribute",
+            "object": {
+              "computed_optional_required": "computed",
+              "attribute_types": [
+                {
+                  "name": "obj_list_attr",
+                  "list": {
+                    "object": [
+                      {
+                        "name": "obj_list_obj_attr",
+                        "string": {}
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "name": "list_nested_bool_attribute",
+            "list_nested": {
+              "computed_optional_required": "computed",
+              "nested_object": {
+                "attributes": [
+                  {
+                    "name": "bool_attribute",
+                    "bool": {
+                      "computed_optional_required": "computed"
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "name": "list_nested_list_nested_bool_attribute",
+            "list_nested": {
+              "computed_optional_required": "computed",
+              "nested_object": {
+                "attributes": [
+                  {
+                    "name": "list_nested_attribute",
+                    "list_nested": {
+                      "computed_optional_required": "computed",
+                      "nested_object": {
+                        "attributes": [
+                          {
+                            "name": "bool_attribute",
+                            "bool": {
+                              "computed_optional_required": "computed"
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "name": "list_nested_list_nested_list_attribute",
+            "list_nested": {
+              "computed_optional_required": "computed",
+              "nested_object": {
+                "attributes": [
+                  {
+                    "name": "list_nested_attribute",
+                    "list_nested": {
+                      "computed_optional_required": "computed",
+                      "nested_object": {
+                        "attributes": [
+                          {
+                            "name": "list_attribute",
+                            "list": {
+                              "computed_optional_required": "computed",
+                              "element_type": {
+                                "string": {}
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "name": "set_attribute",
+            "set": {
+              "computed_optional_required": "computed",
+              "element_type": {
+                "string": {}
+              }
+            }
+          },
+          {
+            "name": "set_attribute_default_custom",
+            "set": {
+              "computed_optional_required": "optional",
+              "default": {
+                "custom": {
+                  "import":           "github.com/hashicorp/terraform-plugin-framework/types",
+                  "schema_definition": "types.SetValueMust(types.String, []attr.Value{types.StringValue(\"example\")})"
+                }
+              },
+              "element_type": {
+                "string": {}
+              }
+            }
+          },
+          {
+            "name": "set_nested_bool_attribute",
+            "set_nested": {
+              "computed_optional_required": "computed",
+              "nested_object": {
+                "attributes": [
+                  {
+                    "name": "bool_attribute",
+                    "bool": {
+                      "computed_optional_required": "computed"
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "name": "single_nested_bool_attribute",
+            "single_nested": {
+              "associated_external_type": {
+                "import": "example.com/apisdk",
+                "type": "*apisdk.DataSourceProperty"
+              },
+              "attributes": [
+                {
+                  "name": "bool_attribute",
+                  "bool": {
+                    "computed_optional_required": "computed"
+                  }
+                }
+              ],
+              "computed_optional_required": "computed"
+            }
+          },
+          {
+            "name": "single_nested_single_nested_bool_attribute",
+            "single_nested": {
+              "attributes": [
+                {
+                  "name": "single_nested_attribute",
+                  "single_nested": {
+                    "attributes": [
+                      {
+                        "name": "bool_attribute",
+                        "bool": {
+                          "computed_optional_required": "computed"
+                        }
+                      }
+                    ],
+                    "computed_optional_required": "computed"
+                  }
+                }
+              ],
+              "computed_optional_required": "computed"
+            }
+          },
+          {
+            "name": "single_nested_single_nested_list_attribute",
+            "single_nested": {
+              "attributes": [
+                {
+                  "name": "single_nested_attribute",
+                  "single_nested": {
+                    "attributes": [
+                      {
+                        "name": "list_attribute",
+                        "list": {
+                          "computed_optional_required": "computed",
+                          "element_type": {
+                            "string": {}
+                          }
+                        }
+                      }
+                    ],
+                    "computed_optional_required": "computed"
+                  }
+                }
+              ],
+              "computed_optional_required": "computed"
+            }
+          },
+          {
+            "name": "string_attribute",
+            "string": {
+              "computed_optional_required": "computed"
+            }
+          },
+          {
+            "name": "string_attribute_default_static",
+            "string": {
+              "computed_optional_required": "optional",
+              "default": {
+                "static": "example"
+              }
+            }
+          }
+        ],
+        "blocks": [
+          {
+            "name": "list_nested_block_bool_attribute",
+            "list_nested": {
+              "nested_object": {
+                "attributes": [
+                  {
+                    "name": "bool_attribute",
+                    "bool": {
+                      "computed_optional_required": "computed"
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "name": "list_nested_list_nested_block_bool_attribute",
+            "list_nested": {
+              "nested_object": {
+                "blocks": [
+                  {
+                    "name": "list_nested_block",
+                    "list_nested": {
+                      "nested_object": {
+                        "attributes": [
+                          {
+                            "name": "bool_attribute",
+                            "bool": {
+                              "computed_optional_required": "computed"
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "name": "list_nested_block_object_attribute_list_nested_nested_block_list_attribute",
+            "list_nested": {
+              "nested_object": {
+                "attributes": [
+                  {
+                    "name": "object_attribute",
+                    "object": {
+                      "computed_optional_required": "computed",
+                      "attribute_types": [
+                        {
+                          "name": "obj_string_attr",
+                          "string": {}
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "blocks": [
+                  {
+                    "name": "list_nested_block",
+                    "list_nested": {
+                      "nested_object": {
+                        "attributes": [
+                          {
+                            "name": "list_attribute",
+                            "list": {
+                              "computed_optional_required": "computed",
+                              "element_type": {
+                                "string": {}
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "name": "set_nested_block_bool_attribute",
+            "set_nested": {
+              "nested_object": {
+                "attributes": [
+                  {
+                    "name": "bool_attribute",
+                    "bool": {
+                      "computed_optional_required": "computed"
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "name": "single_nested_block_bool_attribute",
+            "single_nested": {
+              "attributes": [
+                {
+                  "name": "bool_attribute",
+                  "bool": {
+                    "computed_optional_required": "computed"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "name": "single_nested_single_nested_block_bool_attribute",
+            "single_nested": {
+              "blocks": [
+                {
+                  "name": "single_nested_block",
+                  "single_nested": {
+                    "attributes": [
+                      {
+                        "name": "bool_attribute",
+                        "bool": {
+                          "computed_optional_required": "computed"
+                        }
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "name": "single_nested_block_object_attribute_single_nested_list_nested_block_list_attribute",
+            "single_nested": {
+              "attributes": [
+                {
+                  "name": "object_attribute",
+                  "object": {
+                    "computed_optional_required": "computed",
+                    "attribute_types": [
+                      {
+                        "name": "obj_string_attr",
+                        "string": {}
+                      }
+                    ]
+                  }
+                }
+              ],
+              "blocks": [
+                {
+                  "name": "list_nested_block",
+                  "list_nested": {
+                    "nested_object": {
+                      "attributes": [
+                        {
+                          "name": "list_attribute",
+                          "list": {
+                            "computed_optional_required": "computed",
+                            "element_type": {
+                              "string": {}
+                            }
+                          }
+                        }
+                      ]
+                    }
                   }
                 }
               ]

--- a/spec/schema.json
+++ b/spec/schema.json
@@ -217,6 +217,42 @@
         "oneOf": [
           {
             "$ref": "#/$defs/resource_bool_attribute"
+          },
+          {
+            "$ref": "#/$defs/resource_float64_attribute"
+          },
+          {
+            "$ref": "#/$defs/resource_int64_attribute"
+          },
+          {
+            "$ref": "#/$defs/resource_list_attribute"
+          },
+          {
+            "$ref": "#/$defs/resource_list_nested_attribute"
+          },
+          {
+            "$ref": "#/$defs/resource_map_attribute"
+          },
+          {
+            "$ref": "#/$defs/resource_map_nested_attribute"
+          },
+          {
+            "$ref": "#/$defs/resource_number_attribute"
+          },
+          {
+            "$ref": "#/$defs/resource_object_attribute"
+          },
+          {
+            "$ref": "#/$defs/resource_set_attribute"
+          },
+          {
+            "$ref": "#/$defs/resource_set_nested_attribute"
+          },
+          {
+            "$ref": "#/$defs/resource_single_nested_attribute"
+          },
+          {
+            "$ref": "#/$defs/resource_string_attribute"
           }
         ]
       }
@@ -224,7 +260,17 @@
     "resource_blocks": {
       "type": "array",
       "items": {
-        "oneOf": []
+        "oneOf": [
+          {
+            "$ref": "#/$defs/resource_list_nested_block"
+          },
+          {
+            "$ref": "#/$defs/resource_set_nested_block"
+          },
+          {
+            "$ref": "#/$defs/resource_single_nested_block"
+          }
+        ]
       }
     },
         "schema_associated_external_type": {
@@ -1423,6 +1469,58 @@
         "single_nested"
       ]
     },
+    "resource_nested_attribute_object": {
+      "type": "object",
+      "properties": {
+        "attributes": {
+          "$ref": "#/$defs/resource_attributes"
+        },
+        "custom_type": {
+          "$ref": "#/$defs/schema_custom_type"
+        },
+        "plan_modifiers": {
+          "$ref": "#/$defs/schema_object_plan_modifiers"
+        },
+        "validators": {
+          "$ref": "#/$defs/schema_object_validators"
+        }
+      },
+      "required": [
+        "attributes"
+      ]
+    },
+    "resource_nested_block_object": {
+      "type": "object",
+      "properties": {
+        "attributes": {
+          "$ref": "#/$defs/resource_attributes"
+        },
+        "blocks": {
+          "$ref": "#/$defs/resource_blocks"
+        },
+        "custom_type": {
+          "$ref": "#/$defs/schema_custom_type"
+        },
+        "plan_modifiers": {
+          "$ref": "#/$defs/schema_object_plan_modifiers"
+        },
+        "validators": {
+          "$ref": "#/$defs/schema_object_validators"
+        }
+      },
+      "anyOf": [
+        {
+          "required": [
+            "attributes"
+          ]
+        },
+        {
+          "required": [
+            "blocks"
+          ]
+        }
+      ]
+    },
     "resource_bool_attribute": {
       "type": "object",
       "additionalProperties": false,
@@ -1467,6 +1565,733 @@
       "required": [
         "name",
         "bool"
+      ]
+    },
+    "resource_float64_attribute": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "float64": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "computed_optional_required": {
+              "$ref": "#/$defs/schema_computed_optional_required"
+            },
+            "custom_type": {
+              "$ref": "#/$defs/schema_custom_type"
+            },
+            "default": {
+              "$ref": "#/$defs/schema_float64_default"
+            },
+            "deprecation_message": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "plan_modifiers": {
+              "$ref": "#/$defs/schema_float64_plan_modifiers"
+            },
+            "sensitive": {
+              "type": "boolean"
+            },
+            "validators": {
+              "$ref": "#/$defs/schema_float64_validators"
+            }          },
+          "required": [
+            "computed_optional_required"
+          ]
+        }
+      },
+      "required": [
+        "name",
+        "float64"
+      ]
+    },
+    "resource_int64_attribute": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "int64": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "computed_optional_required": {
+              "$ref": "#/$defs/schema_computed_optional_required"
+            },
+            "custom_type": {
+              "$ref": "#/$defs/schema_custom_type"
+            },
+            "default": {
+              "$ref": "#/$defs/schema_int64_default"
+            },
+            "deprecation_message": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "plan_modifiers": {
+              "$ref": "#/$defs/schema_int64_plan_modifiers"
+            },
+            "sensitive": {
+              "type": "boolean"
+            },
+            "validators": {
+              "$ref": "#/$defs/schema_int64_validators"
+            }          },
+          "required": [
+            "computed_optional_required"
+          ]
+        }
+      },
+      "required": [
+        "name",
+        "int64"
+      ]
+    },
+    "resource_list_attribute": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "list": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "computed_optional_required": {
+              "$ref": "#/$defs/schema_computed_optional_required"
+            },
+            "custom_type": {
+              "$ref": "#/$defs/schema_custom_type"
+            },
+            "default": {
+              "$ref": "#/$defs/schema_list_default"
+            },
+            "deprecation_message": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "element_type": {
+              "$ref": "#/$defs/schema_element_type"
+            },
+            "plan_modifiers": {
+              "$ref": "#/$defs/schema_list_plan_modifiers"
+            },
+            "sensitive": {
+              "type": "boolean"
+            },
+            "validators": {
+              "$ref": "#/$defs/schema_list_validators"
+            }
+          },
+          "required": [
+            "computed_optional_required",
+            "element_type"
+          ]
+        }
+      },
+      "required": [
+        "name",
+        "list"
+      ]
+    },
+    "resource_list_nested_attribute": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "list_nested": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "computed_optional_required": {
+              "$ref": "#/$defs/schema_computed_optional_required"
+            },
+            "custom_type": {
+              "$ref": "#/$defs/schema_custom_type"
+            },
+            "default": {
+              "$ref": "#/$defs/schema_list_default"
+            },
+            "deprecation_message": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "nested_object": {
+              "$ref": "#/$defs/resource_nested_attribute_object"
+            },
+            "plan_modifiers": {
+              "$ref": "#/$defs/schema_list_plan_modifiers"
+            },
+            "sensitive": {
+              "type": "boolean"
+            },
+            "validators": {
+              "$ref": "#/$defs/schema_list_validators"
+            }
+          },
+          "required": [
+            "computed_optional_required",
+            "nested_object"
+          ]
+        }
+      },
+      "required": [
+        "name",
+        "list_nested"
+      ]
+    },
+    "resource_list_nested_block": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "pattern": "^[^\\s]*$"
+        },
+        "list_nested": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "custom_type": {
+              "$ref": "#/$defs/schema_custom_type"
+            },
+            "default": {
+              "$ref": "#/$defs/schema_list_default"
+            },
+            "deprecation_message": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "nested_object": {
+              "$ref": "#/$defs/resource_nested_block_object"
+            },
+            "plan_modifiers": {
+              "$ref": "#/$defs/schema_list_plan_modifiers"
+            },
+            "validators": {
+              "$ref": "#/$defs/schema_list_validators"
+            }
+          },
+          "required": [
+            "nested_object"
+          ]
+        }
+      },
+      "required": [
+        "name",
+        "list_nested"
+      ]
+    },
+    "resource_map_attribute": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "map": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "computed_optional_required": {
+              "$ref": "#/$defs/schema_computed_optional_required"
+            },
+            "custom_type": {
+              "$ref": "#/$defs/schema_custom_type"
+            },
+            "default": {
+              "$ref": "#/$defs/schema_map_default"
+            },
+            "deprecation_message": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "element_type": {
+              "$ref": "#/$defs/schema_element_type"
+            },
+            "plan_modifiers": {
+              "$ref": "#/$defs/schema_map_plan_modifiers"
+            },
+            "sensitive": {
+              "type": "boolean"
+            },
+            "validators": {
+              "$ref": "#/$defs/schema_map_validators"
+            }
+          },
+          "required": [
+            "computed_optional_required",
+            "element_type"
+          ]
+        }
+      },
+      "required": [
+        "name",
+        "map"
+      ]
+    },
+    "resource_map_nested_attribute": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "map_nested": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "computed_optional_required": {
+              "$ref": "#/$defs/schema_computed_optional_required"
+            },
+            "custom_type": {
+              "$ref": "#/$defs/schema_custom_type"
+            },
+            "default": {
+              "$ref": "#/$defs/schema_map_default"
+            },
+            "deprecation_message": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "nested_object": {
+              "$ref": "#/$defs/resource_nested_attribute_object"
+            },
+            "plan_modifiers": {
+              "$ref": "#/$defs/schema_map_plan_modifiers"
+            },
+            "sensitive": {
+              "type": "boolean"
+            },
+            "validators": {
+              "$ref": "#/$defs/schema_map_validators"
+            }
+          },
+          "required": [
+            "computed_optional_required",
+            "nested_object"
+          ]
+        }
+      },
+      "required": [
+        "name",
+        "map_nested"
+      ]
+    },
+    "resource_number_attribute": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "number": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "computed_optional_required": {
+              "$ref": "#/$defs/schema_computed_optional_required"
+            },
+            "custom_type": {
+              "$ref": "#/$defs/schema_custom_type"
+            },
+            "default": {
+              "$ref": "#/$defs/schema_number_default"
+            },
+            "deprecation_message": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "plan_modifiers": {
+              "$ref": "#/$defs/schema_number_plan_modifiers"
+            },
+            "sensitive": {
+              "type": "boolean"
+            },
+            "validators": {
+              "$ref": "#/$defs/schema_number_validators"
+            }          },
+          "required": [
+            "computed_optional_required"
+          ]
+        }
+      },
+      "required": [
+        "name",
+        "number"
+      ]
+    },
+    "resource_object_attribute": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "object": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "attribute_types": {
+              "$ref": "#/$defs/schema_object_elements"
+            },
+            "computed_optional_required": {
+              "$ref": "#/$defs/schema_computed_optional_required"
+            },
+            "custom_type": {
+              "$ref": "#/$defs/schema_custom_type"
+            },
+            "default": {
+              "$ref": "#/$defs/schema_object_default"
+            },
+            "deprecation_message": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "plan_modifiers": {
+              "$ref": "#/$defs/schema_object_plan_modifiers"
+            },
+            "sensitive": {
+              "type": "boolean"
+            },
+            "validators": {
+              "$ref": "#/$defs/schema_object_validators"
+            }
+          },
+          "required": [
+            "attribute_types",
+            "computed_optional_required"
+          ]
+        }
+      },
+      "required": [
+        "name",
+        "object"
+      ]
+    },
+    "resource_set_attribute": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "set": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "computed_optional_required": {
+              "$ref": "#/$defs/schema_computed_optional_required"
+            },
+            "custom_type": {
+              "$ref": "#/$defs/schema_custom_type"
+            },
+            "default": {
+              "$ref": "#/$defs/schema_set_default"
+            },
+            "deprecation_message": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "element_type": {
+              "$ref": "#/$defs/schema_element_type"
+            },
+            "plan_modifiers": {
+              "$ref": "#/$defs/schema_set_plan_modifiers"
+            },
+            "sensitive": {
+              "type": "boolean"
+            },
+            "validators": {
+              "$ref": "#/$defs/schema_set_validators"
+            }
+          },
+          "required": [
+            "computed_optional_required",
+            "element_type"
+          ]
+        }
+      },
+      "required": [
+        "name",
+        "set"
+      ]
+    },
+    "resource_set_nested_attribute": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "set_nested": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "computed_optional_required": {
+              "$ref": "#/$defs/schema_computed_optional_required"
+            },
+            "custom_type": {
+              "$ref": "#/$defs/schema_custom_type"
+            },
+            "default": {
+              "$ref": "#/$defs/schema_set_default"
+            },
+            "deprecation_message": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "nested_object": {
+              "$ref": "#/$defs/resource_nested_attribute_object"
+            },
+            "plan_modifiers": {
+              "$ref": "#/$defs/schema_set_plan_modifiers"
+            },
+            "sensitive": {
+              "type": "boolean"
+            },
+            "validators": {
+              "$ref": "#/$defs/schema_set_validators"
+            }
+          },
+          "required": [
+            "computed_optional_required",
+            "nested_object"
+          ]
+        }
+      },
+      "required": [
+        "name",
+        "set_nested"
+      ]
+    },
+    "resource_set_nested_block": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "pattern": "^[^\\s]*$"
+        },
+        "set_nested": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "custom_type": {
+              "$ref": "#/$defs/schema_custom_type"
+            },
+            "default": {
+              "$ref": "#/$defs/schema_set_default"
+            },
+            "deprecation_message": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "nested_object": {
+              "$ref": "#/$defs/resource_nested_block_object"
+            },
+            "plan_modifiers": {
+              "$ref": "#/$defs/schema_set_plan_modifiers"
+            },
+            "validators": {
+              "$ref": "#/$defs/schema_set_validators"
+            }
+          },
+          "required": [
+            "nested_object"
+          ]
+        }
+      },
+      "required": [
+        "name",
+        "set_nested"
+      ]
+    },
+    "resource_single_nested_attribute": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "single_nested": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "associated_external_type": {
+              "$ref": "#/$defs/schema_associated_external_type"
+            },
+            "attributes": {
+              "$ref": "#/$defs/resource_attributes"
+            },
+            "computed_optional_required": {
+              "$ref": "#/$defs/schema_computed_optional_required"
+            },
+            "custom_type": {
+              "$ref": "#/$defs/schema_custom_type"
+            },
+            "default": {
+              "$ref": "#/$defs/schema_object_default"
+            },
+            "deprecation_message": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "plan_modifiers": {
+              "$ref": "#/$defs/schema_object_plan_modifiers"
+            },
+            "sensitive": {
+              "type": "boolean"
+            },
+            "validators": {
+              "$ref": "#/$defs/schema_object_validators"
+            }
+          },
+          "required": [
+            "attributes",
+            "computed_optional_required"
+          ]
+        }
+      },
+      "required": [
+        "name",
+        "single_nested"
+      ]
+    },
+    "resource_single_nested_block": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "pattern": "^[^\\s]*$"
+        },
+        "single_nested": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "attributes": {
+              "$ref": "#/$defs/resource_attributes"
+            },
+            "blocks": {
+              "$ref": "#/$defs/resource_blocks"
+            },
+            "custom_type": {
+              "$ref": "#/$defs/schema_custom_type"
+            },
+            "default": {
+              "$ref": "#/$defs/schema_object_default"
+            },
+            "deprecation_message": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "plan_modifiers": {
+              "$ref": "#/$defs/schema_object_plan_modifiers"
+            },
+            "validators": {
+              "$ref": "#/$defs/schema_object_validators"
+            }
+          },
+          "anyOf": [
+            {
+              "required": [
+                "attributes"
+              ]
+            },
+            {
+              "required": [
+                "blocks"
+              ]
+            }
+          ]
+        }
+      },
+      "required": [
+        "name",
+        "single_nested"
+      ]
+    },
+    "resource_string_attribute": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "string": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "computed_optional_required": {
+              "$ref": "#/$defs/schema_computed_optional_required"
+            },
+            "custom_type": {
+              "$ref": "#/$defs/schema_custom_type"
+            },
+            "default": {
+              "$ref": "#/$defs/schema_string_default"
+            },
+            "deprecation_message": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "plan_modifiers": {
+              "$ref": "#/$defs/schema_string_plan_modifiers"
+            },
+            "sensitive": {
+              "type": "boolean"
+            },
+            "validators": {
+              "$ref": "#/$defs/schema_string_validators"
+            }          },
+          "required": [
+            "computed_optional_required"
+          ]
+        }
+      },
+      "required": [
+        "name",
+        "string"
       ]
     },
     "schema_bool_default": {
@@ -1590,6 +2415,68 @@
         "schema_definition"
       ]
     },
+    "schema_float64_default": {
+      "type": "object",
+      "properties": {
+        "custom": {
+          "$ref": "#/$defs/schema_custom_default"
+        },
+        "static": {
+          "type": "number"
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "custom"
+          ]
+        },
+        {
+          "required": [
+            "static"
+          ]
+        }
+      ]
+    },
+    "schema_float64_plan_modifier": {
+      "type": "object",
+      "properties": {
+        "custom": {
+          "$ref": "#/$defs/schema_custom_plan_modifier"
+        },
+        "requires_replace": {
+          "type": "object",
+          "additionalProperties": false
+        },
+        "use_state_for_unknown": {
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "custom"
+          ]
+        },
+        {
+          "required": [
+            "requires_replace"
+          ]
+        },
+        {
+          "required": [
+            "use_state_for_unknown"
+          ]
+        }
+      ]
+    },
+    "schema_float64_plan_modifiers": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/schema_float64_plan_modifier"
+      }
+    },
     "schema_float64_validator": {
       "type": "object",
       "properties": {
@@ -1605,6 +2492,68 @@
       "type": "array",
       "items": {
         "$ref": "#/$defs/schema_float64_validator"
+      }
+    },
+    "schema_int64_default": {
+      "type": "object",
+      "properties": {
+        "custom": {
+          "$ref": "#/$defs/schema_custom_default"
+        },
+        "static": {
+          "type": "number"
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "custom"
+          ]
+        },
+        {
+          "required": [
+            "static"
+          ]
+        }
+      ]
+    },
+    "schema_int64_plan_modifier": {
+      "type": "object",
+      "properties": {
+        "custom": {
+          "$ref": "#/$defs/schema_custom_plan_modifier"
+        },
+        "requires_replace": {
+          "type": "object",
+          "additionalProperties": false
+        },
+        "use_state_for_unknown": {
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "custom"
+          ]
+        },
+        {
+          "required": [
+            "requires_replace"
+          ]
+        },
+        {
+          "required": [
+            "use_state_for_unknown"
+          ]
+        }
+      ]
+    },
+    "schema_int64_plan_modifiers": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/schema_int64_plan_modifier"
       }
     },
     "schema_int64_validator": {
@@ -1624,6 +2573,60 @@
         "$ref": "#/$defs/schema_int64_validator"
       }
     },
+    "schema_list_default": {
+      "type": "object",
+      "properties": {
+        "custom": {
+          "$ref": "#/$defs/schema_custom_default"
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "custom"
+          ]
+        }
+      ]
+    },
+    "schema_list_plan_modifier": {
+      "type": "object",
+      "properties": {
+        "custom": {
+          "$ref": "#/$defs/schema_custom_plan_modifier"
+        },
+        "requires_replace": {
+          "type": "object",
+          "additionalProperties": false
+        },
+        "use_state_for_unknown": {
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "custom"
+          ]
+        },
+        {
+          "required": [
+            "requires_replace"
+          ]
+        },
+        {
+          "required": [
+            "use_state_for_unknown"
+          ]
+        }
+      ]
+    },
+    "schema_list_plan_modifiers": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/schema_list_plan_modifier"
+      }
+    },
     "schema_list_validator": {
       "type": "object",
       "properties": {
@@ -1639,6 +2642,60 @@
       "type": "array",
       "items": {
         "$ref": "#/$defs/schema_list_validator"
+      }
+    },
+    "schema_map_default": {
+      "type": "object",
+      "properties": {
+        "custom": {
+          "$ref": "#/$defs/schema_custom_default"
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "custom"
+          ]
+        }
+      ]
+    },
+    "schema_map_plan_modifier": {
+      "type": "object",
+      "properties": {
+        "custom": {
+          "$ref": "#/$defs/schema_custom_plan_modifier"
+        },
+        "requires_replace": {
+          "type": "object",
+          "additionalProperties": false
+        },
+        "use_state_for_unknown": {
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "custom"
+          ]
+        },
+        {
+          "required": [
+            "requires_replace"
+          ]
+        },
+        {
+          "required": [
+            "use_state_for_unknown"
+          ]
+        }
+      ]
+    },
+    "schema_map_plan_modifiers": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/schema_map_plan_modifier"
       }
     },
     "schema_map_validator": {
@@ -1658,6 +2715,60 @@
         "$ref": "#/$defs/schema_map_validator"
       }
     },
+    "schema_number_default": {
+      "type": "object",
+      "properties": {
+        "custom": {
+          "$ref": "#/$defs/schema_custom_default"
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "custom"
+          ]
+        }
+      ]
+    },
+    "schema_number_plan_modifier": {
+      "type": "object",
+      "properties": {
+        "custom": {
+          "$ref": "#/$defs/schema_custom_plan_modifier"
+        },
+        "requires_replace": {
+          "type": "object",
+          "additionalProperties": false
+        },
+        "use_state_for_unknown": {
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "custom"
+          ]
+        },
+        {
+          "required": [
+            "requires_replace"
+          ]
+        },
+        {
+          "required": [
+            "use_state_for_unknown"
+          ]
+        }
+      ]
+    },
+    "schema_number_plan_modifiers": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/schema_number_plan_modifier"
+      }
+    },
     "schema_number_validator": {
       "type": "object",
       "properties": {
@@ -1673,6 +2784,60 @@
       "type": "array",
       "items": {
         "$ref": "#/$defs/schema_number_validator"
+      }
+    },
+    "schema_object_default": {
+      "type": "object",
+      "properties": {
+        "custom": {
+          "$ref": "#/$defs/schema_custom_default"
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "custom"
+          ]
+        }
+      ]
+    },
+    "schema_object_plan_modifier": {
+      "type": "object",
+      "properties": {
+        "custom": {
+          "$ref": "#/$defs/schema_custom_plan_modifier"
+        },
+        "requires_replace": {
+          "type": "object",
+          "additionalProperties": false
+        },
+        "use_state_for_unknown": {
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "custom"
+          ]
+        },
+        {
+          "required": [
+            "requires_replace"
+          ]
+        },
+        {
+          "required": [
+            "use_state_for_unknown"
+          ]
+        }
+      ]
+    },
+    "schema_object_plan_modifiers": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/schema_object_plan_modifier"
       }
     },
     "schema_object_validator": {
@@ -1692,6 +2857,60 @@
         "$ref": "#/$defs/schema_object_validator"
       }
     },
+    "schema_set_default": {
+      "type": "object",
+      "properties": {
+        "custom": {
+          "$ref": "#/$defs/schema_custom_default"
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "custom"
+          ]
+        }
+      ]
+    },
+    "schema_set_plan_modifier": {
+      "type": "object",
+      "properties": {
+        "custom": {
+          "$ref": "#/$defs/schema_custom_plan_modifier"
+        },
+        "requires_replace": {
+          "type": "object",
+          "additionalProperties": false
+        },
+        "use_state_for_unknown": {
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "custom"
+          ]
+        },
+        {
+          "required": [
+            "requires_replace"
+          ]
+        },
+        {
+          "required": [
+            "use_state_for_unknown"
+          ]
+        }
+      ]
+    },
+    "schema_set_plan_modifiers": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/schema_set_plan_modifier"
+      }
+    },
     "schema_set_validator": {
       "type": "object",
       "properties": {
@@ -1707,6 +2926,68 @@
       "type": "array",
       "items": {
         "$ref": "#/$defs/schema_set_validator"
+      }
+    },
+    "schema_string_default": {
+      "type": "object",
+      "properties": {
+        "custom": {
+          "$ref": "#/$defs/schema_custom_default"
+        },
+        "static": {
+          "type": "string"
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "custom"
+          ]
+        },
+        {
+          "required": [
+            "static"
+          ]
+        }
+      ]
+    },
+    "schema_string_plan_modifier": {
+      "type": "object",
+      "properties": {
+        "custom": {
+          "$ref": "#/$defs/schema_custom_plan_modifier"
+        },
+        "requires_replace": {
+          "type": "object",
+          "additionalProperties": false
+        },
+        "use_state_for_unknown": {
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "custom"
+          ]
+        },
+        {
+          "required": [
+            "requires_replace"
+          ]
+        },
+        {
+          "required": [
+            "use_state_for_unknown"
+          ]
+        }
+      ]
+    },
+    "schema_string_plan_modifiers": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/schema_string_plan_modifier"
       }
     },
     "schema_string_validator": {

--- a/spec/specification_test.go
+++ b/spec/specification_test.go
@@ -582,9 +582,6 @@ func TestSpecification_JSONUnmarshal(t *testing.T) {
 											Type:      "",
 											ValueType: "",
 										},
-										Default: &schema.BoolDefault{
-											Static: pointer(true),
-										},
 										PlanModifiers: []schema.BoolPlanModifier{
 											{},
 											{
@@ -599,6 +596,567 @@ func TestSpecification_JSONUnmarshal(t *testing.T) {
 												Custom: &schema.CustomValidator{
 													Import:           pointer("github.com/my_account/my_project/myboolvalidator"),
 													SchemaDefinition: "myboolvalidator.Validate()",
+												},
+											},
+										},
+									},
+								},
+								{
+									Name: "bool_attribute_default_static",
+									Bool: &resource.BoolAttribute{
+										ComputedOptionalRequired: schema.Optional,
+										Default: &schema.BoolDefault{
+											Static: pointer(true),
+										},
+									},
+								},
+								{
+									Name: "float64_attribute",
+									Float64: &resource.Float64Attribute{
+										ComputedOptionalRequired: schema.Computed,
+									},
+								},
+								{
+									Name: "float64_attribute_default_static",
+									Float64: &resource.Float64Attribute{
+										ComputedOptionalRequired: schema.Optional,
+										Default: &schema.Float64Default{
+											Static: pointer(123.45),
+										},
+									},
+								},
+								{
+									Name: "int64_attribute",
+									Int64: &resource.Int64Attribute{
+										ComputedOptionalRequired: schema.Computed,
+									},
+								},
+								{
+									Name: "int64_attribute_default_static",
+									Int64: &resource.Int64Attribute{
+										ComputedOptionalRequired: schema.Optional,
+										Default: &schema.Int64Default{
+											Static: pointer(int64(123)),
+										},
+									},
+								},
+								{
+									Name: "list_attribute",
+									List: &resource.ListAttribute{
+										ComputedOptionalRequired: schema.Computed,
+										ElementType: schema.ElementType{
+											String: &schema.StringType{},
+										},
+									},
+								},
+								{
+									Name: "list_attribute_default_custom",
+									List: &resource.ListAttribute{
+										ComputedOptionalRequired: schema.Optional,
+										Default: &schema.ListDefault{
+											Custom: &schema.CustomDefault{
+												Import:           pointer("github.com/hashicorp/terraform-plugin-framework/types"),
+												SchemaDefinition: "types.ListValueMust(types.String, []attr.Value{types.StringValue(\"example\")})",
+											},
+										},
+										ElementType: schema.ElementType{
+											String: &schema.StringType{},
+										},
+									},
+								},
+								{
+									Name: "list_map_attribute",
+									List: &resource.ListAttribute{
+										ComputedOptionalRequired: schema.Computed,
+										ElementType: schema.ElementType{
+											Map: &schema.MapType{
+												ElementType: schema.ElementType{
+													String: &schema.StringType{},
+												},
+											},
+										},
+									},
+								},
+								{
+									Name: "list_object_attribute",
+									List: &resource.ListAttribute{
+										ComputedOptionalRequired: schema.Computed,
+										ElementType: schema.ElementType{
+											Object: []schema.ObjectAttributeType{
+												{
+													Name:   "obj_string_attr",
+													String: &schema.StringType{},
+												},
+											},
+										},
+									},
+								},
+								{
+									Name: "list_object_object_attribute",
+									List: &resource.ListAttribute{
+										ComputedOptionalRequired: schema.Computed,
+										ElementType: schema.ElementType{
+											Object: []schema.ObjectAttributeType{
+												{
+													Name: "obj_obj_attr",
+													Object: []schema.ObjectAttributeType{
+														{
+															Name:   "obj_obj_string_attr",
+															String: &schema.StringType{},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+								{
+									Name: "map_attribute",
+									Map: &resource.MapAttribute{
+										ComputedOptionalRequired: schema.Computed,
+										ElementType: schema.ElementType{
+											String: &schema.StringType{},
+										},
+									},
+								},
+								{
+									Name: "map_nested_bool_attribute",
+									MapNested: &resource.MapNestedAttribute{
+										ComputedOptionalRequired: schema.Computed,
+										NestedObject: resource.NestedAttributeObject{
+											Attributes: []resource.Attribute{
+												{
+													Name: "bool_attribute",
+													Bool: &resource.BoolAttribute{
+														ComputedOptionalRequired: schema.Computed,
+													},
+												},
+											},
+										},
+									},
+								},
+								{
+									Name: "number_attribute",
+									Number: &resource.NumberAttribute{
+										ComputedOptionalRequired: schema.Computed,
+									},
+								},
+								{
+									Name: "number_attribute_default_custom",
+									Number: &resource.NumberAttribute{
+										ComputedOptionalRequired: schema.Optional,
+										Default: &schema.NumberDefault{
+											Custom: &schema.CustomDefault{
+												Import:           pointer("math/big"),
+												SchemaDefinition: "big.NewFloat(123.45)",
+											},
+										},
+									},
+								},
+								{
+									Name: "object_attribute",
+									Object: &resource.ObjectAttribute{
+										AttributeTypes: []schema.ObjectAttributeType{
+											{
+												Name:   "obj_string_attr",
+												String: &schema.StringType{},
+											},
+										},
+										ComputedOptionalRequired: schema.Computed,
+									},
+								},
+								{
+									Name: "object_list_attribute",
+									Object: &resource.ObjectAttribute{
+										AttributeTypes: []schema.ObjectAttributeType{
+											{
+												Name: "obj_list_attr",
+												List: &schema.ListType{
+													ElementType: schema.ElementType{
+														String: &schema.StringType{},
+													},
+												},
+											},
+										},
+										ComputedOptionalRequired: schema.Computed,
+									},
+								},
+								{
+									Name: "object_list_object_attribute",
+									Object: &resource.ObjectAttribute{
+										AttributeTypes: []schema.ObjectAttributeType{
+											{
+												Name: "obj_list_attr",
+												List: &schema.ListType{
+													ElementType: schema.ElementType{
+														Object: []schema.ObjectAttributeType{
+															{
+																Name:   "obj_list_obj_attr",
+																String: &schema.StringType{},
+															},
+														},
+													},
+												},
+											},
+										},
+										ComputedOptionalRequired: schema.Computed,
+									},
+								},
+								{
+									Name: "list_nested_bool_attribute",
+									ListNested: &resource.ListNestedAttribute{
+										ComputedOptionalRequired: schema.Computed,
+										NestedObject: resource.NestedAttributeObject{
+											Attributes: []resource.Attribute{
+												{
+													Name: "bool_attribute",
+													Bool: &resource.BoolAttribute{
+														ComputedOptionalRequired: schema.Computed,
+													},
+												},
+											},
+										},
+									},
+								},
+								{
+									Name: "list_nested_list_nested_bool_attribute",
+									ListNested: &resource.ListNestedAttribute{
+										ComputedOptionalRequired: schema.Computed,
+										NestedObject: resource.NestedAttributeObject{
+											Attributes: []resource.Attribute{
+												{
+													Name: "list_nested_attribute",
+													ListNested: &resource.ListNestedAttribute{
+														ComputedOptionalRequired: schema.Computed,
+														NestedObject: resource.NestedAttributeObject{
+															Attributes: []resource.Attribute{
+																{
+																	Name: "bool_attribute",
+																	Bool: &resource.BoolAttribute{
+																		ComputedOptionalRequired: schema.Computed,
+																	},
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+								{
+									Name: "list_nested_list_nested_list_attribute",
+									ListNested: &resource.ListNestedAttribute{
+										ComputedOptionalRequired: schema.Computed,
+										NestedObject: resource.NestedAttributeObject{
+											Attributes: []resource.Attribute{
+												{
+													Name: "list_nested_attribute",
+													ListNested: &resource.ListNestedAttribute{
+														ComputedOptionalRequired: schema.Computed,
+														NestedObject: resource.NestedAttributeObject{
+															Attributes: []resource.Attribute{
+																{
+																	Name: "list_attribute",
+																	List: &resource.ListAttribute{
+																		ComputedOptionalRequired: schema.Computed,
+																		ElementType: schema.ElementType{
+																			String: &schema.StringType{},
+																		},
+																	},
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+								{
+									Name: "set_attribute",
+									Set: &resource.SetAttribute{
+										ComputedOptionalRequired: schema.Computed,
+										ElementType: schema.ElementType{
+											String: &schema.StringType{},
+										},
+									},
+								},
+								{
+									Name: "set_attribute_default_custom",
+									Set: &resource.SetAttribute{
+										ComputedOptionalRequired: schema.Optional,
+										Default: &schema.SetDefault{
+											Custom: &schema.CustomDefault{
+												Import:           pointer("github.com/hashicorp/terraform-plugin-framework/types"),
+												SchemaDefinition: "types.SetValueMust(types.String, []attr.Value{types.StringValue(\"example\")})",
+											},
+										},
+										ElementType: schema.ElementType{
+											String: &schema.StringType{},
+										},
+									},
+								},
+								{
+									Name: "set_nested_bool_attribute",
+									SetNested: &resource.SetNestedAttribute{
+										ComputedOptionalRequired: schema.Computed,
+										NestedObject: resource.NestedAttributeObject{
+											Attributes: []resource.Attribute{
+												{
+													Name: "bool_attribute",
+													Bool: &resource.BoolAttribute{
+														ComputedOptionalRequired: schema.Computed,
+													},
+												},
+											},
+										},
+									},
+								},
+								{
+									Name: "single_nested_bool_attribute",
+									SingleNested: &resource.SingleNestedAttribute{
+										AssociatedExternalType: &schema.AssociatedExternalType{
+											Import: pointer("example.com/apisdk"),
+											Type:   "*apisdk.DataSourceProperty",
+										},
+										Attributes: []resource.Attribute{
+											{
+												Name: "bool_attribute",
+												Bool: &resource.BoolAttribute{
+													ComputedOptionalRequired: schema.Computed,
+												},
+											},
+										},
+										ComputedOptionalRequired: schema.Computed,
+									},
+								},
+								{
+									Name: "single_nested_single_nested_bool_attribute",
+									SingleNested: &resource.SingleNestedAttribute{
+										Attributes: []resource.Attribute{
+											{
+												Name: "single_nested_attribute",
+												SingleNested: &resource.SingleNestedAttribute{
+													Attributes: []resource.Attribute{
+														{
+															Name: "bool_attribute",
+															Bool: &resource.BoolAttribute{
+																ComputedOptionalRequired: schema.Computed,
+															},
+														},
+													},
+													ComputedOptionalRequired: schema.Computed,
+												},
+											},
+										},
+										ComputedOptionalRequired: schema.Computed,
+									},
+								},
+								{
+									Name: "single_nested_single_nested_list_attribute",
+									SingleNested: &resource.SingleNestedAttribute{
+										Attributes: []resource.Attribute{
+											{
+												Name: "single_nested_attribute",
+												SingleNested: &resource.SingleNestedAttribute{
+													Attributes: []resource.Attribute{
+														{
+															Name: "list_attribute",
+															List: &resource.ListAttribute{
+																ComputedOptionalRequired: schema.Computed,
+																ElementType: schema.ElementType{
+																	String: &schema.StringType{},
+																},
+															},
+														},
+													},
+													ComputedOptionalRequired: schema.Computed,
+												},
+											},
+										},
+										ComputedOptionalRequired: schema.Computed,
+									},
+								},
+								{
+									Name: "string_attribute",
+									String: &resource.StringAttribute{
+										ComputedOptionalRequired: schema.Computed,
+									},
+								},
+								{
+									Name: "string_attribute_default_static",
+									String: &resource.StringAttribute{
+										ComputedOptionalRequired: schema.Optional,
+										Default: &schema.StringDefault{
+											Static: pointer("example"),
+										},
+									},
+								},
+							},
+							Blocks: []resource.Block{
+								{
+									Name: "list_nested_block_bool_attribute",
+									ListNested: &resource.ListNestedBlock{
+										NestedObject: resource.NestedBlockObject{
+											Attributes: []resource.Attribute{
+												{
+													Name: "bool_attribute",
+													Bool: &resource.BoolAttribute{
+														ComputedOptionalRequired: schema.Computed,
+													},
+												},
+											},
+										},
+									},
+								},
+								{
+									Name: "list_nested_list_nested_block_bool_attribute",
+									ListNested: &resource.ListNestedBlock{
+										NestedObject: resource.NestedBlockObject{
+											Blocks: []resource.Block{
+												{
+													Name: "list_nested_block",
+													ListNested: &resource.ListNestedBlock{
+														NestedObject: resource.NestedBlockObject{
+															Attributes: []resource.Attribute{
+																{
+																	Name: "bool_attribute",
+																	Bool: &resource.BoolAttribute{
+																		ComputedOptionalRequired: schema.Computed,
+																	},
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+								{
+									Name: "list_nested_block_object_attribute_list_nested_nested_block_list_attribute",
+									ListNested: &resource.ListNestedBlock{
+										NestedObject: resource.NestedBlockObject{
+											Attributes: []resource.Attribute{
+												{
+													Name: "object_attribute",
+													Object: &resource.ObjectAttribute{
+														AttributeTypes: []schema.ObjectAttributeType{
+															{
+																Name:   "obj_string_attr",
+																String: &schema.StringType{},
+															},
+														},
+														ComputedOptionalRequired: schema.Computed,
+													},
+												},
+											},
+											Blocks: []resource.Block{
+												{
+													Name: "list_nested_block",
+													ListNested: &resource.ListNestedBlock{
+														NestedObject: resource.NestedBlockObject{
+															Attributes: []resource.Attribute{
+																{
+																	Name: "list_attribute",
+																	List: &resource.ListAttribute{
+																		ComputedOptionalRequired: schema.Computed,
+																		ElementType: schema.ElementType{
+																			String: &schema.StringType{},
+																		},
+																	},
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+								{
+									Name: "set_nested_block_bool_attribute",
+									SetNested: &resource.SetNestedBlock{
+										NestedObject: resource.NestedBlockObject{
+											Attributes: []resource.Attribute{
+												{
+													Name: "bool_attribute",
+													Bool: &resource.BoolAttribute{
+														ComputedOptionalRequired: schema.Computed,
+													},
+												},
+											},
+										},
+									},
+								},
+								{
+									Name: "single_nested_block_bool_attribute",
+									SingleNested: &resource.SingleNestedBlock{
+										Attributes: []resource.Attribute{
+											{
+												Name: "bool_attribute",
+												Bool: &resource.BoolAttribute{
+													ComputedOptionalRequired: schema.Computed,
+												},
+											},
+										},
+									},
+								},
+								{
+									Name: "single_nested_single_nested_block_bool_attribute",
+									SingleNested: &resource.SingleNestedBlock{
+										Blocks: []resource.Block{
+											{
+												Name: "single_nested_block",
+												SingleNested: &resource.SingleNestedBlock{
+													Attributes: []resource.Attribute{
+														{
+															Name: "bool_attribute",
+															Bool: &resource.BoolAttribute{
+																ComputedOptionalRequired: schema.Computed,
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+								{
+									Name: "single_nested_block_object_attribute_single_nested_list_nested_block_list_attribute",
+									SingleNested: &resource.SingleNestedBlock{
+										Attributes: []resource.Attribute{
+											{
+												Name: "object_attribute",
+												Object: &resource.ObjectAttribute{
+													AttributeTypes: []schema.ObjectAttributeType{
+														{
+															Name:   "obj_string_attr",
+															String: &schema.StringType{},
+														},
+													},
+													ComputedOptionalRequired: schema.Computed,
+												},
+											},
+										},
+										Blocks: []resource.Block{
+											{
+												Name: "list_nested_block",
+												ListNested: &resource.ListNestedBlock{
+													NestedObject: resource.NestedBlockObject{
+														Attributes: []resource.Attribute{
+															{
+																Name: "list_attribute",
+																List: &resource.ListAttribute{
+																	ComputedOptionalRequired: schema.Computed,
+																	ElementType: schema.ElementType{
+																		String: &schema.StringType{},
+																	},
+																},
+															},
+														},
+													},
 												},
 											},
 										},


### PR DESCRIPTION
Mainly a duplication of the datasource schema spec and types, with the addition of default and plan modifier functionality. This intentionally omits list, number, map, object, and set static defaults as they will require additional design considerations.