### PR TITLE
Introduce provider schema spec and types

### DIFF
--- a/provider/attribute.go
+++ b/provider/attribute.go
@@ -1,0 +1,175 @@
+package provider
+
+import "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
+
+type Attribute struct {
+	Name string `json:"name"`
+
+	Bool         *BoolAttribute         `json:"bool,omitempty"`
+	Float64      *Float64Attribute      `json:"float64,omitempty"`
+	Int64        *Int64Attribute        `json:"int64,omitempty"`
+	List         *ListAttribute         `json:"list,omitempty"`
+	ListNested   *ListNestedAttribute   `json:"list_nested,omitempty"`
+	Map          *MapAttribute          `json:"map,omitempty"`
+	MapNested    *MapNestedAttribute    `json:"map_nested,omitempty"`
+	Number       *NumberAttribute       `json:"number,omitempty"`
+	Object       *ObjectAttribute       `json:"object,omitempty"`
+	Set          *SetAttribute          `json:"set,omitempty"`
+	SetNested    *SetNestedAttribute    `json:"set_nested,omitempty"`
+	SingleNested *SingleNestedAttribute `json:"single_nested,omitempty"`
+	String       *StringAttribute       `json:"string,omitempty"`
+}
+
+type NestedAttributeObject struct {
+	Attributes []Attribute `json:"attributes,omitempty"`
+
+	CustomType *schema.CustomType       `json:"custom_type,omitempty"`
+	Validators []schema.ObjectValidator `json:"validators,omitempty"`
+}
+
+type BoolAttribute struct {
+	OptionalRequired schema.OptionalRequired `json:"optional_required"`
+
+	AssociatedExternalType *schema.AssociatedExternalType `json:"associated_external_type,omitempty"`
+	CustomType             *schema.CustomType             `json:"custom_type,omitempty"`
+	DeprecationMessage     *string                        `json:"deprecation_message,omitempty"`
+	Description            *string                        `json:"description,omitempty"`
+	Sensitive              *bool                          `json:"sensitive,omitempty"`
+	Validators             []schema.BoolValidator         `json:"validators,omitempty"`
+}
+
+type Float64Attribute struct {
+	OptionalRequired schema.OptionalRequired `json:"optional_required"`
+
+	AssociatedExternalType *schema.AssociatedExternalType `json:"associated_external_type,omitempty"`
+	CustomType             *schema.CustomType             `json:"custom_type,omitempty"`
+	DeprecationMessage     *string                        `json:"deprecation_message,omitempty"`
+	Description            *string                        `json:"description,omitempty"`
+	Sensitive              *bool                          `json:"sensitive,omitempty"`
+	Validators             []schema.Float64Validator      `json:"validators,omitempty"`
+}
+
+type Int64Attribute struct {
+	OptionalRequired schema.OptionalRequired `json:"optional_required"`
+
+	AssociatedExternalType *schema.AssociatedExternalType `json:"associated_external_type,omitempty"`
+	CustomType             *schema.CustomType             `json:"custom_type,omitempty"`
+	DeprecationMessage     *string                        `json:"deprecation_message,omitempty"`
+	Description            *string                        `json:"description,omitempty"`
+	Sensitive              *bool                          `json:"sensitive,omitempty"`
+	Validators             []schema.Int64Validator        `json:"validators,omitempty"`
+}
+
+type ListAttribute struct {
+	OptionalRequired schema.OptionalRequired `json:"optional_required"`
+	ElementType      schema.ElementType      `json:"element_type"`
+
+	AssociatedExternalType *schema.AssociatedExternalType `json:"associated_external_type,omitempty"`
+	CustomType             *schema.CustomType             `json:"custom_type,omitempty"`
+	DeprecationMessage     *string                        `json:"deprecation_message,omitempty"`
+	Description            *string                        `json:"description,omitempty"`
+	Sensitive              *bool                          `json:"sensitive,omitempty"`
+	Validators             []schema.ListValidator         `json:"validators,omitempty"`
+}
+
+type ListNestedAttribute struct {
+	OptionalRequired schema.OptionalRequired `json:"optional_required"`
+	NestedObject     NestedAttributeObject   `json:"nested_object"`
+
+	CustomType         *schema.CustomType     `json:"custom_type,omitempty"`
+	DeprecationMessage *string                `json:"deprecation_message,omitempty"`
+	Description        *string                `json:"description,omitempty"`
+	Sensitive          *bool                  `json:"sensitive,omitempty"`
+	Validators         []schema.ListValidator `json:"validators,omitempty"`
+}
+
+type MapAttribute struct {
+	OptionalRequired schema.OptionalRequired `json:"optional_required"`
+	ElementType      schema.ElementType      `json:"element_type"`
+
+	AssociatedExternalType *schema.AssociatedExternalType `json:"associated_external_type,omitempty"`
+	CustomType             *schema.CustomType             `json:"custom_type,omitempty"`
+	DeprecationMessage     *string                        `json:"deprecation_message,omitempty"`
+	Description            *string                        `json:"description,omitempty"`
+	Sensitive              *bool                          `json:"sensitive,omitempty"`
+	Validators             []schema.MapValidator          `json:"validators,omitempty"`
+}
+
+type MapNestedAttribute struct {
+	OptionalRequired schema.OptionalRequired `json:"optional_required"`
+	NestedObject     NestedAttributeObject   `json:"nested_object"`
+
+	CustomType         *schema.CustomType    `json:"custom_type,omitempty"`
+	DeprecationMessage *string               `json:"deprecation_message,omitempty"`
+	Description        *string               `json:"description,omitempty"`
+	Sensitive          *bool                 `json:"sensitive,omitempty"`
+	Validators         []schema.MapValidator `json:"validators,omitempty"`
+}
+
+type NumberAttribute struct {
+	OptionalRequired schema.OptionalRequired `json:"optional_required"`
+
+	AssociatedExternalType *schema.AssociatedExternalType `json:"associated_external_type,omitempty"`
+	CustomType             *schema.CustomType             `json:"custom_type,omitempty"`
+	DeprecationMessage     *string                        `json:"deprecation_message,omitempty"`
+	Description            *string                        `json:"description,omitempty"`
+	Sensitive              *bool                          `json:"sensitive,omitempty"`
+	Validators             []schema.NumberValidator       `json:"validators,omitempty"`
+}
+
+type ObjectAttribute struct {
+	AttributeTypes   []schema.ObjectAttributeType `json:"attribute_types"`
+	OptionalRequired schema.OptionalRequired      `json:"optional_required"`
+
+	AssociatedExternalType *schema.AssociatedExternalType `json:"associated_external_type,omitempty"`
+	CustomType             *schema.CustomType             `json:"custom_type,omitempty"`
+	DeprecationMessage     *string                        `json:"deprecation_message,omitempty"`
+	Description            *string                        `json:"description,omitempty"`
+	Sensitive              *bool                          `json:"sensitive,omitempty"`
+	Validators             []schema.ObjectValidator       `json:"validators,omitempty"`
+}
+
+type SetAttribute struct {
+	OptionalRequired schema.OptionalRequired `json:"optional_required"`
+	ElementType      schema.ElementType      `json:"element_type"`
+
+	AssociatedExternalType *schema.AssociatedExternalType `json:"associated_external_type,omitempty"`
+	CustomType             *schema.CustomType             `json:"custom_type,omitempty"`
+	DeprecationMessage     *string                        `json:"deprecation_message,omitempty"`
+	Description            *string                        `json:"description,omitempty"`
+	Sensitive              *bool                          `json:"sensitive,omitempty"`
+	Validators             []schema.SetValidator          `json:"validators,omitempty"`
+}
+
+type SetNestedAttribute struct {
+	OptionalRequired schema.OptionalRequired `json:"optional_required"`
+	NestedObject     NestedAttributeObject   `json:"nested_object"`
+
+	CustomType         *schema.CustomType    `json:"custom_type,omitempty"`
+	DeprecationMessage *string               `json:"deprecation_message,omitempty"`
+	Description        *string               `json:"description,omitempty"`
+	Sensitive          *bool                 `json:"sensitive,omitempty"`
+	Validators         []schema.SetValidator `json:"validators,omitempty"`
+}
+
+type SingleNestedAttribute struct {
+	OptionalRequired       schema.OptionalRequired        `json:"optional_required"`
+	Attributes             []Attribute                    `json:"attributes,omitempty"`
+	AssociatedExternalType *schema.AssociatedExternalType `json:"associated_external_type,omitempty"`
+	CustomType             *schema.CustomType             `json:"custom_type,omitempty"`
+	DeprecationMessage     *string                        `json:"deprecation_message,omitempty"`
+	Description            *string                        `json:"description,omitempty"`
+	Sensitive              *bool                          `json:"sensitive,omitempty"`
+	Validators             []schema.ObjectValidator       `json:"validators,omitempty"`
+}
+
+type StringAttribute struct {
+	OptionalRequired schema.OptionalRequired `json:"optional_required"`
+
+	AssociatedExternalType *schema.AssociatedExternalType `json:"associated_external_type,omitempty"`
+	CustomType             *schema.CustomType             `json:"custom_type,omitempty"`
+	DeprecationMessage     *string                        `json:"deprecation_message,omitempty"`
+	Description            *string                        `json:"description,omitempty"`
+	Sensitive              *bool                          `json:"sensitive,omitempty"`
+	Validators             []schema.StringValidator       `json:"validators,omitempty"`
+}

--- a/provider/block.go
+++ b/provider/block.go
@@ -1,0 +1,54 @@
+package provider
+
+import "github.com/hashicorp/terraform-plugin-codegen-spec/schema"
+
+type Block struct {
+	Name string `json:"name"`
+
+	ListNested   *ListNestedBlock   `json:"list_nested,omitempty"`
+	SetNested    *SetNestedBlock    `json:"set_nested,omitempty"`
+	SingleNested *SingleNestedBlock `json:"single_nested,omitempty"`
+}
+
+type NestedBlockObject struct {
+	Attributes []Attribute `json:"attributes,omitempty"`
+	Blocks     []Block     `json:"blocks,omitempty"`
+
+	CustomType *schema.CustomType       `json:"custom_type,omitempty"`
+	Validators []schema.ObjectValidator `json:"validators,omitempty"`
+}
+
+type ListNestedBlock struct {
+	OptionalRequired schema.OptionalRequired `json:"optional_required"`
+	NestedObject     NestedBlockObject       `json:"nested_object"`
+
+	CustomType         *schema.CustomType     `json:"custom_type,omitempty"`
+	DeprecationMessage *string                `json:"deprecation_message,omitempty"`
+	Description        *string                `json:"description,omitempty"`
+	Sensitive          *bool                  `json:"sensitive,omitempty"`
+	Validators         []schema.ListValidator `json:"validators,omitempty"`
+}
+
+type SetNestedBlock struct {
+	OptionalRequired schema.OptionalRequired `json:"optional_required"`
+	NestedObject     NestedBlockObject       `json:"nested_object"`
+
+	CustomType         *schema.CustomType    `json:"custom_type,omitempty"`
+	DeprecationMessage *string               `json:"deprecation_message,omitempty"`
+	Description        *string               `json:"description,omitempty"`
+	Sensitive          *bool                 `json:"sensitive,omitempty"`
+	Validators         []schema.SetValidator `json:"validators,omitempty"`
+}
+
+type SingleNestedBlock struct {
+	Attributes       []Attribute             `json:"attributes,omitempty"`
+	Blocks           []Block                 `json:"blocks,omitempty"`
+	OptionalRequired schema.OptionalRequired `json:"optional_required"`
+
+	AssociatedExternalType *schema.AssociatedExternalType `json:"associated_external_type,omitempty"`
+	CustomType             *schema.CustomType             `json:"custom_type,omitempty"`
+	DeprecationMessage     *string                        `json:"deprecation_message,omitempty"`
+	Description            *string                        `json:"description,omitempty"`
+	Sensitive              *bool                          `json:"sensitive,omitempty"`
+	Validators             []schema.ObjectValidator       `json:"validators,omitempty"`
+}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -2,4 +2,6 @@ package provider
 
 type Provider struct {
 	Name string `json:"name"`
+
+	Schema *Schema `json:"schema,omitempty"`
 }

--- a/provider/schema.go
+++ b/provider/schema.go
@@ -1,0 +1,6 @@
+package provider
+
+type Schema struct {
+	Attributes []Attribute `json:"attributes,omitempty"`
+	Blocks     []Block     `json:"blocks,omitempty"`
+}

--- a/schema/computed_optional_required.go
+++ b/schema/computed_optional_required.go
@@ -8,3 +8,5 @@ const (
 )
 
 type ComputedOptionalRequired string
+
+type OptionalRequired = ComputedOptionalRequired

--- a/spec/example.json
+++ b/spec/example.json
@@ -492,7 +492,494 @@
     }
   ],
   "provider": {
-    "name": "provider"
+    "name": "provider",
+    "schema": {
+      "attributes": [
+        {
+          "name": "bool_attribute",
+          "bool": {
+            "optional_required": "optional"
+          }
+        },
+        {
+          "name": "float64_attribute",
+          "float64": {
+            "optional_required": "optional"
+          }
+        },
+        {
+          "name": "int64_attribute",
+          "int64": {
+            "optional_required": "optional"
+          }
+        },
+        {
+          "name": "list_attribute",
+          "list": {
+            "optional_required": "optional",
+            "element_type": {
+              "string": {}
+            }
+          }
+        },
+        {
+          "name": "list_map_attribute",
+          "list": {
+            "optional_required": "optional",
+            "element_type": {
+              "map": {
+                "string": {}
+              }
+            }
+          }
+        },
+        {
+          "name": "list_object_attribute",
+          "list": {
+            "optional_required": "optional",
+            "element_type": {
+              "object": [
+                {
+                  "name": "obj_string_attr",
+                  "string": {}
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "list_object_object_attribute",
+          "list": {
+            "optional_required": "optional",
+            "element_type": {
+              "object": [
+                {
+                  "name": "obj_obj_attr",
+                  "object": [
+                    {
+                      "name": "obj_obj_string_attr",
+                      "string": {}
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "map_attribute",
+          "map": {
+            "optional_required": "optional",
+            "element_type": {
+              "string": {}
+            }
+          }
+        },
+        {
+          "name": "map_nested_bool_attribute",
+          "map_nested": {
+            "optional_required": "optional",
+            "nested_object": {
+              "attributes": [
+                {
+                  "name": "bool_attribute",
+                  "bool": {
+                    "optional_required": "optional"
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "number_attribute",
+          "number": {
+            "optional_required": "optional"
+          }
+        },
+        {
+          "name": "object_attribute",
+          "object": {
+            "optional_required": "optional",
+            "attribute_types": [
+              {
+                "name": "obj_string_attr",
+                "string": {}
+              }
+            ]
+          }
+        },
+        {
+          "name": "object_list_attribute",
+          "object": {
+            "optional_required": "optional",
+            "attribute_types": [
+              {
+                "name": "obj_list_attr",
+                "list": {
+                  "string": {}
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "object_list_object_attribute",
+          "object": {
+            "optional_required": "optional",
+            "attribute_types": [
+              {
+                "name": "obj_list_attr",
+                "list": {
+                  "object": [
+                    {
+                      "name": "obj_list_obj_attr",
+                      "string": {}
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "list_nested_bool_attribute",
+          "list_nested": {
+            "optional_required": "optional",
+            "nested_object": {
+              "attributes": [
+                {
+                  "name": "bool_attribute",
+                  "bool": {
+                    "optional_required": "optional"
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "list_nested_list_nested_bool_attribute",
+          "list_nested": {
+            "optional_required": "optional",
+            "nested_object": {
+              "attributes": [
+                {
+                  "name": "list_nested_attribute",
+                  "list_nested": {
+                    "optional_required": "optional",
+                    "nested_object": {
+                      "attributes": [
+                        {
+                          "name": "bool_attribute",
+                          "bool": {
+                            "optional_required": "optional"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "list_nested_list_nested_list_attribute",
+          "list_nested": {
+            "optional_required": "optional",
+            "nested_object": {
+              "attributes": [
+                {
+                  "name": "list_nested_attribute",
+                  "list_nested": {
+                    "optional_required": "optional",
+                    "nested_object": {
+                      "attributes": [
+                        {
+                          "name": "list_attribute",
+                          "list": {
+                            "optional_required": "optional",
+                            "element_type": {
+                              "string": {}
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "set_attribute",
+          "set": {
+            "optional_required": "optional",
+            "element_type": {
+              "string": {}
+            }
+          }
+        },
+        {
+          "name": "set_nested_bool_attribute",
+          "set_nested": {
+            "optional_required": "optional",
+            "nested_object": {
+              "attributes": [
+                {
+                  "name": "bool_attribute",
+                  "bool": {
+                    "optional_required": "optional"
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "single_nested_bool_attribute",
+          "single_nested": {
+            "associated_external_type": {
+              "import": "example.com/apisdk",
+              "type": "*apisdk.ProviderProperty"
+            },
+            "attributes": [
+              {
+                "name": "bool_attribute",
+                "bool": {
+                  "optional_required": "optional"
+                }
+              }
+            ],
+            "optional_required": "optional"
+          }
+        },
+        {
+          "name": "single_nested_single_nested_bool_attribute",
+          "single_nested": {
+            "attributes": [
+              {
+                "name": "single_nested_attribute",
+                "single_nested": {
+                  "attributes": [
+                    {
+                      "name": "bool_attribute",
+                      "bool": {
+                        "optional_required": "optional"
+                      }
+                    }
+                  ],
+                  "optional_required": "optional"
+                }
+              }
+            ],
+            "optional_required": "optional"
+          }
+        },
+        {
+          "name": "single_nested_single_nested_list_attribute",
+          "single_nested": {
+            "attributes": [
+              {
+                "name": "single_nested_attribute",
+                "single_nested": {
+                  "attributes": [
+                    {
+                      "name": "list_attribute",
+                      "list": {
+                        "optional_required": "optional",
+                        "element_type": {
+                          "string": {}
+                        }
+                      }
+                    }
+                  ],
+                  "optional_required": "optional"
+                }
+              }
+            ],
+            "optional_required": "optional"
+          }
+        },
+        {
+          "name": "string_attribute",
+          "string": {
+            "optional_required": "optional"
+          }
+        }
+      ],
+      "blocks": [
+        {
+          "name": "list_nested_block_bool_attribute",
+          "list_nested": {
+            "nested_object": {
+              "attributes": [
+                {
+                  "name": "bool_attribute",
+                  "bool": {
+                    "optional_required": "optional"
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "list_nested_list_nested_block_bool_attribute",
+          "list_nested": {
+            "nested_object": {
+              "blocks": [
+                {
+                  "name": "list_nested_block",
+                  "list_nested": {
+                    "nested_object": {
+                      "attributes": [
+                        {
+                          "name": "bool_attribute",
+                          "bool": {
+                            "optional_required": "optional"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "list_nested_block_object_attribute_list_nested_nested_block_list_attribute",
+          "list_nested": {
+            "nested_object": {
+              "attributes": [
+                {
+                  "name": "object_attribute",
+                  "object": {
+                    "optional_required": "optional",
+                    "attribute_types": [
+                      {
+                        "name": "obj_string_attr",
+                        "string": {}
+                      }
+                    ]
+                  }
+                }
+              ],
+              "blocks": [
+                {
+                  "name": "list_nested_block",
+                  "list_nested": {
+                    "nested_object": {
+                      "attributes": [
+                        {
+                          "name": "list_attribute",
+                          "list": {
+                            "optional_required": "optional",
+                            "element_type": {
+                              "string": {}
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "set_nested_block_bool_attribute",
+          "set_nested": {
+            "nested_object": {
+              "attributes": [
+                {
+                  "name": "bool_attribute",
+                  "bool": {
+                    "optional_required": "optional"
+                  }
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "single_nested_block_bool_attribute",
+          "single_nested": {
+            "attributes": [
+              {
+                "name": "bool_attribute",
+                "bool": {
+                  "optional_required": "optional"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "single_nested_single_nested_block_bool_attribute",
+          "single_nested": {
+            "blocks": [
+              {
+                "name": "single_nested_block",
+                "single_nested": {
+                  "attributes": [
+                    {
+                      "name": "bool_attribute",
+                      "bool": {
+                        "optional_required": "optional"
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "single_nested_block_object_attribute_single_nested_list_nested_block_list_attribute",
+          "single_nested": {
+            "attributes": [
+              {
+                "name": "object_attribute",
+                "object": {
+                  "optional_required": "optional",
+                  "attribute_types": [
+                    {
+                      "name": "obj_string_attr",
+                      "string": {}
+                    }
+                  ]
+                }
+              }
+            ],
+            "blocks": [
+              {
+                "name": "list_nested_block",
+                "list_nested": {
+                  "nested_object": {
+                    "attributes": [
+                      {
+                        "name": "list_attribute",
+                        "list": {
+                          "optional_required": "optional",
+                          "element_type": {
+                            "string": {}
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
   },
   "resources": [
     {

--- a/spec/schema.json
+++ b/spec/schema.json
@@ -143,34 +143,74 @@
       "type": "object",
       "properties": {
         "attributes": {
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "oneOf": [
-            ]
-          },
-          "blocks": {
-            "type": "array",
-            "minItems": 1,
-            "oneOf": {
-              "type": [
-              ]
-            }
-          }
-        }
-      },
-      "anyOf": [
-        {
-          "required": [
-            "attributes"
-          ]
+          "$ref": "#/$defs/provider_attributes"
         },
-        {
-          "required": [
-            "blocks"
-          ]
+        "blocks": {
+          "$ref": "#/$defs/provider_blocks"
         }
-      ]
+      }
+    },
+    "provider_attributes": {
+      "type": "array",
+      "items": {
+        "oneOf": [
+          {
+            "$ref": "#/$defs/provider_bool_attribute"
+          },
+          {
+            "$ref": "#/$defs/provider_float64_attribute"
+          },
+          {
+            "$ref": "#/$defs/provider_int64_attribute"
+          },
+          {
+            "$ref": "#/$defs/provider_list_attribute"
+          },
+          {
+            "$ref": "#/$defs/provider_list_nested_attribute"
+          },
+          {
+            "$ref": "#/$defs/provider_map_attribute"
+          },
+          {
+            "$ref": "#/$defs/provider_map_nested_attribute"
+          },
+          {
+            "$ref": "#/$defs/provider_number_attribute"
+          },
+          {
+            "$ref": "#/$defs/provider_object_attribute"
+          },
+          {
+            "$ref": "#/$defs/provider_set_attribute"
+          },
+          {
+            "$ref": "#/$defs/provider_set_nested_attribute"
+          },
+          {
+            "$ref": "#/$defs/provider_single_nested_attribute"
+          },
+          {
+            "$ref": "#/$defs/provider_string_attribute"
+          }
+        ]
+      }
+    },
+    "provider_blocks": {
+      "type": "array",
+      "items": {
+        "oneOf": [
+          {
+            "$ref": "#/$defs/provider_list_nested_block"
+          },
+          {
+            "$ref": "#/$defs/provider_set_nested_block"
+          },
+          {
+            "$ref": "#/$defs/provider_single_nested_block"
+          }
+        ]
+      }
     },
     "resource": {
       "type": "object",
@@ -661,6 +701,12 @@
                 "string"
               ]
             }
+          ]
+        },
+        "schema_optional_required": {
+          "enum": [
+            "optional",
+            "required"
           ]
         },
         "schema_set_element": {
@@ -1467,6 +1513,728 @@
       "required": [
         "name",
         "single_nested"
+      ]
+    },
+    "provider_nested_attribute_object": {
+      "type": "object",
+      "properties": {
+        "attributes": {
+          "$ref": "#/$defs/provider_attributes"
+        },
+        "custom_type": {
+          "$ref": "#/$defs/schema_custom_type"
+        },
+        "validators": {
+          "$ref": "#/$defs/schema_object_validators"
+        }
+      },
+      "required": [
+        "attributes"
+      ]
+    },
+    "provider_nested_block_object": {
+      "type": "object",
+      "properties": {
+        "attributes": {
+          "$ref": "#/$defs/provider_attributes"
+        },
+        "blocks": {
+          "$ref": "#/$defs/provider_blocks"
+        },
+        "custom_type": {
+          "$ref": "#/$defs/schema_custom_type"
+        },
+        "validators": {
+          "$ref": "#/$defs/schema_object_validators"
+        }
+      },
+      "anyOf": [
+        {
+          "required": [
+            "attributes"
+          ]
+        },
+        {
+          "required": [
+            "blocks"
+          ]
+        }
+      ]
+    },
+    "provider_bool_attribute": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "bool": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "custom_type": {
+              "$ref": "#/$defs/schema_custom_type"
+            },
+            "deprecation_message": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "optional_required": {
+              "$ref": "#/$defs/schema_optional_required"
+            },
+            "sensitive": {
+              "type": "boolean"
+            },
+            "validators": {
+              "$ref": "#/$defs/schema_bool_validators"
+            }          },
+          "required": [
+            "optional_required"
+          ]
+        }
+      },
+      "required": [
+        "name",
+        "bool"
+      ]
+    },
+    "provider_float64_attribute": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "float64": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "custom_type": {
+              "$ref": "#/$defs/schema_custom_type"
+            },
+            "deprecation_message": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "optional_required": {
+              "$ref": "#/$defs/schema_optional_required"
+            },
+            "sensitive": {
+              "type": "boolean"
+            },
+            "validators": {
+              "$ref": "#/$defs/schema_float64_validators"
+            }          },
+          "required": [
+            "optional_required"
+          ]
+        }
+      },
+      "required": [
+        "name",
+        "float64"
+      ]
+    },
+    "provider_int64_attribute": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "int64": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "custom_type": {
+              "$ref": "#/$defs/schema_custom_type"
+            },
+            "deprecation_message": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "optional_required": {
+              "$ref": "#/$defs/schema_optional_required"
+            },
+            "sensitive": {
+              "type": "boolean"
+            },
+            "validators": {
+              "$ref": "#/$defs/schema_int64_validators"
+            }          },
+          "required": [
+            "optional_required"
+          ]
+        }
+      },
+      "required": [
+        "name",
+        "int64"
+      ]
+    },
+    "provider_list_attribute": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "list": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "custom_type": {
+              "$ref": "#/$defs/schema_custom_type"
+            },
+            "deprecation_message": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "element_type": {
+              "$ref": "#/$defs/schema_element_type"
+            },
+            "optional_required": {
+              "$ref": "#/$defs/schema_optional_required"
+            },
+            "sensitive": {
+              "type": "boolean"
+            },
+            "validators": {
+              "$ref": "#/$defs/schema_list_validators"
+            }
+          },
+          "required": [
+            "optional_required",
+            "element_type"
+          ]
+        }
+      },
+      "required": [
+        "name",
+        "list"
+      ]
+    },
+    "provider_list_nested_attribute": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "list_nested": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "custom_type": {
+              "$ref": "#/$defs/schema_custom_type"
+            },
+            "deprecation_message": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "nested_object": {
+              "$ref": "#/$defs/provider_nested_attribute_object"
+            },
+            "optional_required": {
+              "$ref": "#/$defs/schema_optional_required"
+            },
+            "sensitive": {
+              "type": "boolean"
+            },
+            "validators": {
+              "$ref": "#/$defs/schema_list_validators"
+            }
+          },
+          "required": [
+            "optional_required",
+            "nested_object"
+          ]
+        }
+      },
+      "required": [
+        "name",
+        "list_nested"
+      ]
+    },
+    "provider_list_nested_block": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "pattern": "^[^\\s]*$"
+        },
+        "list_nested": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "custom_type": {
+              "$ref": "#/$defs/schema_custom_type"
+            },
+            "deprecation_message": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "nested_object": {
+              "$ref": "#/$defs/provider_nested_block_object"
+            },
+            "validators": {
+              "$ref": "#/$defs/schema_list_validators"
+            }
+          },
+          "required": [
+            "nested_object"
+          ]
+        }
+      },
+      "required": [
+        "name",
+        "list_nested"
+      ]
+    },
+    "provider_map_attribute": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "map": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "custom_type": {
+              "$ref": "#/$defs/schema_custom_type"
+            },
+            "deprecation_message": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "element_type": {
+              "$ref": "#/$defs/schema_element_type"
+            },
+            "optional_required": {
+              "$ref": "#/$defs/schema_optional_required"
+            },
+            "sensitive": {
+              "type": "boolean"
+            },
+            "validators": {
+              "$ref": "#/$defs/schema_map_validators"
+            }
+          },
+          "required": [
+            "optional_required",
+            "element_type"
+          ]
+        }
+      },
+      "required": [
+        "name",
+        "map"
+      ]
+    },
+    "provider_map_nested_attribute": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "map_nested": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "custom_type": {
+              "$ref": "#/$defs/schema_custom_type"
+            },
+            "deprecation_message": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "nested_object": {
+              "$ref": "#/$defs/provider_nested_attribute_object"
+            },
+            "optional_required": {
+              "$ref": "#/$defs/schema_optional_required"
+            },
+            "sensitive": {
+              "type": "boolean"
+            },
+            "validators": {
+              "$ref": "#/$defs/schema_map_validators"
+            }
+          },
+          "required": [
+            "optional_required",
+            "nested_object"
+          ]
+        }
+      },
+      "required": [
+        "name",
+        "map_nested"
+      ]
+    },
+    "provider_number_attribute": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "number": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "custom_type": {
+              "$ref": "#/$defs/schema_custom_type"
+            },
+            "deprecation_message": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "optional_required": {
+              "$ref": "#/$defs/schema_optional_required"
+            },
+            "sensitive": {
+              "type": "boolean"
+            },
+            "validators": {
+              "$ref": "#/$defs/schema_number_validators"
+            }          },
+          "required": [
+            "optional_required"
+          ]
+        }
+      },
+      "required": [
+        "name",
+        "number"
+      ]
+    },
+    "provider_object_attribute": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "object": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "attribute_types": {
+              "$ref": "#/$defs/schema_object_elements"
+            },
+            "custom_type": {
+              "$ref": "#/$defs/schema_custom_type"
+            },
+            "deprecation_message": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "optional_required": {
+              "$ref": "#/$defs/schema_optional_required"
+            },
+            "sensitive": {
+              "type": "boolean"
+            },
+            "validators": {
+              "$ref": "#/$defs/schema_object_validators"
+            }
+          },
+          "required": [
+            "attribute_types",
+            "optional_required"
+          ]
+        }
+      },
+      "required": [
+        "name",
+        "object"
+      ]
+    },
+    "provider_set_attribute": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "set": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "custom_type": {
+              "$ref": "#/$defs/schema_custom_type"
+            },
+            "deprecation_message": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "element_type": {
+              "$ref": "#/$defs/schema_element_type"
+            },
+            "optional_required": {
+              "$ref": "#/$defs/schema_optional_required"
+            },
+            "sensitive": {
+              "type": "boolean"
+            },
+            "validators": {
+              "$ref": "#/$defs/schema_set_validators"
+            }
+          },
+          "required": [
+            "optional_required",
+            "element_type"
+          ]
+        }
+      },
+      "required": [
+        "name",
+        "set"
+      ]
+    },
+    "provider_set_nested_attribute": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "set_nested": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "custom_type": {
+              "$ref": "#/$defs/schema_custom_type"
+            },
+            "deprecation_message": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "nested_object": {
+              "$ref": "#/$defs/provider_nested_attribute_object"
+            },
+            "optional_required": {
+              "$ref": "#/$defs/schema_optional_required"
+            },
+            "sensitive": {
+              "type": "boolean"
+            },
+            "validators": {
+              "$ref": "#/$defs/schema_set_validators"
+            }
+          },
+          "required": [
+            "optional_required",
+            "nested_object"
+          ]
+        }
+      },
+      "required": [
+        "name",
+        "set_nested"
+      ]
+    },
+    "provider_set_nested_block": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "pattern": "^[^\\s]*$"
+        },
+        "set_nested": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "custom_type": {
+              "$ref": "#/$defs/schema_custom_type"
+            },
+            "deprecation_message": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "nested_object": {
+              "$ref": "#/$defs/provider_nested_block_object"
+            },
+            "validators": {
+              "$ref": "#/$defs/schema_set_validators"
+            }
+          },
+          "required": [
+            "nested_object"
+          ]
+        }
+      },
+      "required": [
+        "name",
+        "set_nested"
+      ]
+    },
+    "provider_single_nested_attribute": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "single_nested": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "associated_external_type": {
+              "$ref": "#/$defs/schema_associated_external_type"
+            },
+            "attributes": {
+              "$ref": "#/$defs/provider_attributes"
+            },
+            "custom_type": {
+              "$ref": "#/$defs/schema_custom_type"
+            },
+            "deprecation_message": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "optional_required": {
+              "$ref": "#/$defs/schema_optional_required"
+            },
+            "sensitive": {
+              "type": "boolean"
+            },
+            "validators": {
+              "$ref": "#/$defs/schema_object_validators"
+            }
+          },
+          "required": [
+            "attributes",
+            "optional_required"
+          ]
+        }
+      },
+      "required": [
+        "name",
+        "single_nested"
+      ]
+    },
+    "provider_single_nested_block": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "pattern": "^[^\\s]*$"
+        },
+        "single_nested": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "attributes": {
+              "$ref": "#/$defs/provider_attributes"
+            },
+            "blocks": {
+              "$ref": "#/$defs/provider_blocks"
+            },
+            "custom_type": {
+              "$ref": "#/$defs/schema_custom_type"
+            },
+            "deprecation_message": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "validators": {
+              "$ref": "#/$defs/schema_object_validators"
+            }
+          },
+          "anyOf": [
+            {
+              "required": [
+                "attributes"
+              ]
+            },
+            {
+              "required": [
+                "blocks"
+              ]
+            }
+          ]
+        }
+      },
+      "required": [
+        "name",
+        "single_nested"
+      ]
+    },
+    "provider_string_attribute": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "string": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "custom_type": {
+              "$ref": "#/$defs/schema_custom_type"
+            },
+            "deprecation_message": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "optional_required": {
+              "$ref": "#/$defs/schema_optional_required"
+            },
+            "sensitive": {
+              "type": "boolean"
+            },
+            "validators": {
+              "$ref": "#/$defs/schema_string_validators"
+            }          },
+          "required": [
+            "optional_required"
+          ]
+        }
+      },
+      "required": [
+        "name",
+        "string"
       ]
     },
     "resource_nested_attribute_object": {

--- a/spec/specification_test.go
+++ b/spec/specification_test.go
@@ -567,6 +567,499 @@ func TestSpecification_JSONUnmarshal(t *testing.T) {
 				},
 				Provider: &provider.Provider{
 					Name: "provider",
+					Schema: &provider.Schema{
+						Attributes: []provider.Attribute{
+							{
+								Name: "bool_attribute",
+								Bool: &provider.BoolAttribute{
+									OptionalRequired: schema.Optional,
+								},
+							},
+							{
+								Name: "float64_attribute",
+								Float64: &provider.Float64Attribute{
+									OptionalRequired: schema.Optional,
+								},
+							},
+							{
+								Name: "int64_attribute",
+								Int64: &provider.Int64Attribute{
+									OptionalRequired: schema.Optional,
+								},
+							},
+							{
+								Name: "list_attribute",
+								List: &provider.ListAttribute{
+									OptionalRequired: schema.Optional,
+									ElementType: schema.ElementType{
+										String: &schema.StringType{},
+									},
+								},
+							},
+							{
+								Name: "list_map_attribute",
+								List: &provider.ListAttribute{
+									OptionalRequired: schema.Optional,
+									ElementType: schema.ElementType{
+										Map: &schema.MapType{
+											ElementType: schema.ElementType{
+												String: &schema.StringType{},
+											},
+										},
+									},
+								},
+							},
+							{
+								Name: "list_object_attribute",
+								List: &provider.ListAttribute{
+									OptionalRequired: schema.Optional,
+									ElementType: schema.ElementType{
+										Object: []schema.ObjectAttributeType{
+											{
+												Name:   "obj_string_attr",
+												String: &schema.StringType{},
+											},
+										},
+									},
+								},
+							},
+							{
+								Name: "list_object_object_attribute",
+								List: &provider.ListAttribute{
+									OptionalRequired: schema.Optional,
+									ElementType: schema.ElementType{
+										Object: []schema.ObjectAttributeType{
+											{
+												Name: "obj_obj_attr",
+												Object: []schema.ObjectAttributeType{
+													{
+														Name:   "obj_obj_string_attr",
+														String: &schema.StringType{},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+							{
+								Name: "map_attribute",
+								Map: &provider.MapAttribute{
+									OptionalRequired: schema.Optional,
+									ElementType: schema.ElementType{
+										String: &schema.StringType{},
+									},
+								},
+							},
+							{
+								Name: "map_nested_bool_attribute",
+								MapNested: &provider.MapNestedAttribute{
+									OptionalRequired: schema.Optional,
+									NestedObject: provider.NestedAttributeObject{
+										Attributes: []provider.Attribute{
+											{
+												Name: "bool_attribute",
+												Bool: &provider.BoolAttribute{
+													OptionalRequired: schema.Optional,
+												},
+											},
+										},
+									},
+								},
+							},
+							{
+								Name: "number_attribute",
+								Number: &provider.NumberAttribute{
+									OptionalRequired: schema.Optional,
+								},
+							},
+							{
+								Name: "object_attribute",
+								Object: &provider.ObjectAttribute{
+									AttributeTypes: []schema.ObjectAttributeType{
+										{
+											Name:   "obj_string_attr",
+											String: &schema.StringType{},
+										},
+									},
+									OptionalRequired: schema.Optional,
+								},
+							},
+							{
+								Name: "object_list_attribute",
+								Object: &provider.ObjectAttribute{
+									AttributeTypes: []schema.ObjectAttributeType{
+										{
+											Name: "obj_list_attr",
+											List: &schema.ListType{
+												ElementType: schema.ElementType{
+													String: &schema.StringType{},
+												},
+											},
+										},
+									},
+									OptionalRequired: schema.Optional,
+								},
+							},
+							{
+								Name: "object_list_object_attribute",
+								Object: &provider.ObjectAttribute{
+									AttributeTypes: []schema.ObjectAttributeType{
+										{
+											Name: "obj_list_attr",
+											List: &schema.ListType{
+												ElementType: schema.ElementType{
+													Object: []schema.ObjectAttributeType{
+														{
+															Name:   "obj_list_obj_attr",
+															String: &schema.StringType{},
+														},
+													},
+												},
+											},
+										},
+									},
+									OptionalRequired: schema.Optional,
+								},
+							},
+							{
+								Name: "list_nested_bool_attribute",
+								ListNested: &provider.ListNestedAttribute{
+									OptionalRequired: schema.Optional,
+									NestedObject: provider.NestedAttributeObject{
+										Attributes: []provider.Attribute{
+											{
+												Name: "bool_attribute",
+												Bool: &provider.BoolAttribute{
+													OptionalRequired: schema.Optional,
+												},
+											},
+										},
+									},
+								},
+							},
+							{
+								Name: "list_nested_list_nested_bool_attribute",
+								ListNested: &provider.ListNestedAttribute{
+									OptionalRequired: schema.Optional,
+									NestedObject: provider.NestedAttributeObject{
+										Attributes: []provider.Attribute{
+											{
+												Name: "list_nested_attribute",
+												ListNested: &provider.ListNestedAttribute{
+													OptionalRequired: schema.Optional,
+													NestedObject: provider.NestedAttributeObject{
+														Attributes: []provider.Attribute{
+															{
+																Name: "bool_attribute",
+																Bool: &provider.BoolAttribute{
+																	OptionalRequired: schema.Optional,
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+							{
+								Name: "list_nested_list_nested_list_attribute",
+								ListNested: &provider.ListNestedAttribute{
+									OptionalRequired: schema.Optional,
+									NestedObject: provider.NestedAttributeObject{
+										Attributes: []provider.Attribute{
+											{
+												Name: "list_nested_attribute",
+												ListNested: &provider.ListNestedAttribute{
+													OptionalRequired: schema.Optional,
+													NestedObject: provider.NestedAttributeObject{
+														Attributes: []provider.Attribute{
+															{
+																Name: "list_attribute",
+																List: &provider.ListAttribute{
+																	OptionalRequired: schema.Optional,
+																	ElementType: schema.ElementType{
+																		String: &schema.StringType{},
+																	},
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+							{
+								Name: "set_attribute",
+								Set: &provider.SetAttribute{
+									OptionalRequired: schema.Optional,
+									ElementType: schema.ElementType{
+										String: &schema.StringType{},
+									},
+								},
+							},
+							{
+								Name: "set_nested_bool_attribute",
+								SetNested: &provider.SetNestedAttribute{
+									OptionalRequired: schema.Optional,
+									NestedObject: provider.NestedAttributeObject{
+										Attributes: []provider.Attribute{
+											{
+												Name: "bool_attribute",
+												Bool: &provider.BoolAttribute{
+													OptionalRequired: schema.Optional,
+												},
+											},
+										},
+									},
+								},
+							},
+							{
+								Name: "single_nested_bool_attribute",
+								SingleNested: &provider.SingleNestedAttribute{
+									AssociatedExternalType: &schema.AssociatedExternalType{
+										Import: pointer("example.com/apisdk"),
+										Type:   "*apisdk.ProviderProperty",
+									},
+									Attributes: []provider.Attribute{
+										{
+											Name: "bool_attribute",
+											Bool: &provider.BoolAttribute{
+												OptionalRequired: schema.Optional,
+											},
+										},
+									},
+									OptionalRequired: schema.Optional,
+								},
+							},
+							{
+								Name: "single_nested_single_nested_bool_attribute",
+								SingleNested: &provider.SingleNestedAttribute{
+									Attributes: []provider.Attribute{
+										{
+											Name: "single_nested_attribute",
+											SingleNested: &provider.SingleNestedAttribute{
+												Attributes: []provider.Attribute{
+													{
+														Name: "bool_attribute",
+														Bool: &provider.BoolAttribute{
+															OptionalRequired: schema.Optional,
+														},
+													},
+												},
+												OptionalRequired: schema.Optional,
+											},
+										},
+									},
+									OptionalRequired: schema.Optional,
+								},
+							},
+							{
+								Name: "single_nested_single_nested_list_attribute",
+								SingleNested: &provider.SingleNestedAttribute{
+									Attributes: []provider.Attribute{
+										{
+											Name: "single_nested_attribute",
+											SingleNested: &provider.SingleNestedAttribute{
+												Attributes: []provider.Attribute{
+													{
+														Name: "list_attribute",
+														List: &provider.ListAttribute{
+															OptionalRequired: schema.Optional,
+															ElementType: schema.ElementType{
+																String: &schema.StringType{},
+															},
+														},
+													},
+												},
+												OptionalRequired: schema.Optional,
+											},
+										},
+									},
+									OptionalRequired: schema.Optional,
+								},
+							},
+							{
+								Name: "string_attribute",
+								String: &provider.StringAttribute{
+									OptionalRequired: schema.Optional,
+								},
+							},
+						},
+						Blocks: []provider.Block{
+							{
+								Name: "list_nested_block_bool_attribute",
+								ListNested: &provider.ListNestedBlock{
+									NestedObject: provider.NestedBlockObject{
+										Attributes: []provider.Attribute{
+											{
+												Name: "bool_attribute",
+												Bool: &provider.BoolAttribute{
+													OptionalRequired: schema.Optional,
+												},
+											},
+										},
+									},
+								},
+							},
+							{
+								Name: "list_nested_list_nested_block_bool_attribute",
+								ListNested: &provider.ListNestedBlock{
+									NestedObject: provider.NestedBlockObject{
+										Blocks: []provider.Block{
+											{
+												Name: "list_nested_block",
+												ListNested: &provider.ListNestedBlock{
+													NestedObject: provider.NestedBlockObject{
+														Attributes: []provider.Attribute{
+															{
+																Name: "bool_attribute",
+																Bool: &provider.BoolAttribute{
+																	OptionalRequired: schema.Optional,
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+							{
+								Name: "list_nested_block_object_attribute_list_nested_nested_block_list_attribute",
+								ListNested: &provider.ListNestedBlock{
+									NestedObject: provider.NestedBlockObject{
+										Attributes: []provider.Attribute{
+											{
+												Name: "object_attribute",
+												Object: &provider.ObjectAttribute{
+													AttributeTypes: []schema.ObjectAttributeType{
+														{
+															Name:   "obj_string_attr",
+															String: &schema.StringType{},
+														},
+													},
+													OptionalRequired: schema.Optional,
+												},
+											},
+										},
+										Blocks: []provider.Block{
+											{
+												Name: "list_nested_block",
+												ListNested: &provider.ListNestedBlock{
+													NestedObject: provider.NestedBlockObject{
+														Attributes: []provider.Attribute{
+															{
+																Name: "list_attribute",
+																List: &provider.ListAttribute{
+																	OptionalRequired: schema.Optional,
+																	ElementType: schema.ElementType{
+																		String: &schema.StringType{},
+																	},
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+							{
+								Name: "set_nested_block_bool_attribute",
+								SetNested: &provider.SetNestedBlock{
+									NestedObject: provider.NestedBlockObject{
+										Attributes: []provider.Attribute{
+											{
+												Name: "bool_attribute",
+												Bool: &provider.BoolAttribute{
+													OptionalRequired: schema.Optional,
+												},
+											},
+										},
+									},
+								},
+							},
+							{
+								Name: "single_nested_block_bool_attribute",
+								SingleNested: &provider.SingleNestedBlock{
+									Attributes: []provider.Attribute{
+										{
+											Name: "bool_attribute",
+											Bool: &provider.BoolAttribute{
+												OptionalRequired: schema.Optional,
+											},
+										},
+									},
+								},
+							},
+							{
+								Name: "single_nested_single_nested_block_bool_attribute",
+								SingleNested: &provider.SingleNestedBlock{
+									Blocks: []provider.Block{
+										{
+											Name: "single_nested_block",
+											SingleNested: &provider.SingleNestedBlock{
+												Attributes: []provider.Attribute{
+													{
+														Name: "bool_attribute",
+														Bool: &provider.BoolAttribute{
+															OptionalRequired: schema.Optional,
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+							{
+								Name: "single_nested_block_object_attribute_single_nested_list_nested_block_list_attribute",
+								SingleNested: &provider.SingleNestedBlock{
+									Attributes: []provider.Attribute{
+										{
+											Name: "object_attribute",
+											Object: &provider.ObjectAttribute{
+												AttributeTypes: []schema.ObjectAttributeType{
+													{
+														Name:   "obj_string_attr",
+														String: &schema.StringType{},
+													},
+												},
+												OptionalRequired: schema.Optional,
+											},
+										},
+									},
+									Blocks: []provider.Block{
+										{
+											Name: "list_nested_block",
+											ListNested: &provider.ListNestedBlock{
+												NestedObject: provider.NestedBlockObject{
+													Attributes: []provider.Attribute{
+														{
+															Name: "list_attribute",
+															List: &provider.ListAttribute{
+																OptionalRequired: schema.Optional,
+																ElementType: schema.ElementType{
+																	String: &schema.StringType{},
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
 				},
 				Resources: []resource.Resource{
 					{


### PR DESCRIPTION
Mainly duplicated from the data source spec and types, however provider attributes cannot be computed. The `computed_optional_required` property and `ComputedOptionalRequired` field are replaced with `optional_required` and `OptionalRequired` respectively.