### PR TITLE
Support type customization for object attribute types and collection element types

### DIFF
--- a/schema/bool_type.go
+++ b/schema/bool_type.go
@@ -1,3 +1,6 @@
 package schema
 
-type BoolType struct{}
+type BoolType struct {
+	// CustomType is a customization of the BoolType.
+	CustomType *CustomType `json:"custom_type,omitempty"`
+}

--- a/schema/float64_type.go
+++ b/schema/float64_type.go
@@ -1,3 +1,6 @@
 package schema
 
-type Float64Type struct{}
+type Float64Type struct {
+	// CustomType is a customization of the Float64Type.
+	CustomType *CustomType `json:"custom_type,omitempty"`
+}

--- a/schema/int64_type.go
+++ b/schema/int64_type.go
@@ -1,3 +1,6 @@
 package schema
 
-type Int64Type struct{}
+type Int64Type struct {
+	// CustomType is a customization of the Int64Type.
+	CustomType *CustomType `json:"custom_type,omitempty"`
+}

--- a/schema/list_type.go
+++ b/schema/list_type.go
@@ -2,4 +2,7 @@ package schema
 
 type ListType struct {
 	ElementType
+
+	// CustomType is a customization of the ListType.
+	CustomType *CustomType `json:"custom_type,omitempty"`
 }

--- a/schema/map_type.go
+++ b/schema/map_type.go
@@ -2,4 +2,7 @@ package schema
 
 type MapType struct {
 	ElementType
+
+	// CustomType is a customization of the MapType.
+	CustomType *CustomType `json:"custom_type,omitempty"`
 }

--- a/schema/number_type.go
+++ b/schema/number_type.go
@@ -1,3 +1,6 @@
 package schema
 
-type NumberType struct{}
+type NumberType struct {
+	// CustomType is a customization of the NumberType.
+	CustomType *CustomType `json:"custom_type,omitempty"`
+}

--- a/schema/set_type.go
+++ b/schema/set_type.go
@@ -2,4 +2,7 @@ package schema
 
 type SetType struct {
 	ElementType
+
+	// CustomType is a customization of the SetType.
+	CustomType *CustomType `json:"custom_type,omitempty"`
 }

--- a/schema/string_type.go
+++ b/schema/string_type.go
@@ -1,3 +1,6 @@
 package schema
 
-type StringType struct{}
+type StringType struct {
+	// CustomType is a customization of the StringType.
+	CustomType *CustomType `json:"custom_type,omitempty"`
+}

--- a/spec/example.json
+++ b/spec/example.json
@@ -11,9 +11,31 @@
             }
           },
           {
+            "name": "bool_attribute_custom_type",
+            "bool": {
+              "computed_optional_required": "computed",
+              "custom_type": {
+                "import": "github.com/hashicorp/terraform-plugin-framework/types/basetypes",
+                "type": "basetypes.BoolType",
+                "value_type": "basetypes.BoolValue"
+              }
+            }
+          },
+          {
             "name": "float64_attribute",
             "float64": {
               "computed_optional_required": "computed"
+            }
+          },
+          {
+            "name": "float64_attribute_custom_type",
+            "float64": {
+              "computed_optional_required": "computed",
+              "custom_type": {
+                "import": "github.com/hashicorp/terraform-plugin-framework/types/basetypes",
+                "type": "basetypes.Float64Type",
+                "value_type": "basetypes.Float64Value"
+              }
             }
           },
           {
@@ -23,11 +45,51 @@
             }
           },
           {
+            "name": "int64_attribute_custom_type",
+            "int64": {
+              "computed_optional_required": "computed",
+              "custom_type": {
+                "import": "github.com/hashicorp/terraform-plugin-framework/types/basetypes",
+                "type": "basetypes.Int64Type",
+                "value_type": "basetypes.Int64Value"
+              }
+            }
+          },
+          {
             "name": "list_attribute",
             "list": {
               "computed_optional_required": "computed",
               "element_type": {
                 "string": {}
+              }
+            }
+          },
+          {
+            "name": "list_attribute_custom_type",
+            "list": {
+              "computed_optional_required": "computed",
+              "custom_type": {
+                "import": "github.com/hashicorp/terraform-plugin-framework/types/basetypes",
+                "type": "basetypes.ListType",
+                "value_type": "basetypes.ListValue"
+              },
+              "element_type": {
+                "string": {}
+              }
+            }
+          },
+          {
+            "name": "list_attribute_element_type_string_custom_type",
+            "list": {
+              "computed_optional_required": "computed",
+              "element_type": {
+                "string": {
+                  "custom_type": {
+                    "import": "github.com/hashicorp/terraform-plugin-framework/types/basetypes",
+                    "type": "basetypes.StringType",
+                    "value_type": "basetypes.StringValue"
+                  }
+                }
               }
             }
           },
@@ -85,6 +147,35 @@
             }
           },
           {
+            "name": "map_attribute_custom_type",
+            "map": {
+              "computed_optional_required": "computed",
+              "custom_type": {
+                "import": "github.com/hashicorp/terraform-plugin-framework/types/basetypes",
+                "type": "basetypes.MapType",
+                "value_type": "basetypes.MapValue"
+              },
+              "element_type": {
+                "string": {}
+              }
+            }
+          },
+          {
+            "name": "map_attribute_element_type_string_custom_type",
+            "map": {
+              "computed_optional_required": "computed",
+              "element_type": {
+                "string": {
+                  "custom_type": {
+                    "import": "github.com/hashicorp/terraform-plugin-framework/types/basetypes",
+                    "type": "basetypes.StringType",
+                    "value_type": "basetypes.StringValue"
+                  }
+                }
+              }
+            }
+          },
+          {
             "name": "map_nested_bool_attribute",
             "map_nested": {
               "computed_optional_required": "computed",
@@ -107,9 +198,55 @@
             }
           },
           {
+            "name": "number_attribute_custom_type",
+            "number": {
+              "computed_optional_required": "computed",
+              "custom_type": {
+                "import": "github.com/hashicorp/terraform-plugin-framework/types/basetypes",
+                "type": "basetypes.NumberType",
+                "value_type": "basetypes.NumberValue"
+              }
+            }
+          },
+          {
             "name": "object_attribute",
             "object": {
               "computed_optional_required": "computed",
+              "attribute_types": [
+                {
+                  "name": "obj_string_attr",
+                  "string": {}
+                }
+              ]
+            }
+          },
+          {
+            "name": "object_attribute_attribute_types_string_custom_type",
+            "object": {
+              "computed_optional_required": "computed",
+              "attribute_types": [
+                {
+                  "name": "obj_string_attr",
+                  "string": {
+                    "custom_type": {
+                      "import": "github.com/hashicorp/terraform-plugin-framework/types/basetypes",
+                      "type": "basetypes.StringType",
+                      "value_type": "basetypes.StringValue"
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "name": "object_attribute_custom_type",
+            "object": {
+              "computed_optional_required": "computed",
+              "custom_type": {
+                "import": "github.com/hashicorp/terraform-plugin-framework/types/basetypes",
+                "type": "basetypes.ObjectType",
+                "value_type": "basetypes.ObjectValue"
+              },
               "attribute_types": [
                 {
                   "name": "obj_string_attr",
@@ -232,6 +369,35 @@
             }
           },
           {
+            "name": "set_attribute_custom_type",
+            "set": {
+              "computed_optional_required": "computed",
+              "custom_type": {
+                "import": "github.com/hashicorp/terraform-plugin-framework/types/basetypes",
+                "type": "basetypes.SetType",
+                "value_type": "basetypes.SetValue"
+              },
+              "element_type": {
+                "string": {}
+              }
+            }
+          },
+          {
+            "name": "set_attribute_element_type_string_custom_type",
+            "set": {
+              "computed_optional_required": "computed",
+              "element_type": {
+                "string": {
+                  "custom_type": {
+                    "import": "github.com/hashicorp/terraform-plugin-framework/types/basetypes",
+                    "type": "basetypes.StringType",
+                    "value_type": "basetypes.StringValue"
+                  }
+                }
+              }
+            }
+          },
+          {
             "name": "set_nested_bool_attribute",
             "set_nested": {
               "computed_optional_required": "computed",
@@ -316,6 +482,17 @@
             "name": "string_attribute",
             "string": {
               "computed_optional_required": "computed"
+            }
+          },
+          {
+            "name": "string_attribute_custom_type",
+            "string": {
+              "computed_optional_required": "computed",
+              "custom_type": {
+                "import": "github.com/hashicorp/terraform-plugin-framework/types/basetypes",
+                "type": "basetypes.StringType",
+                "value_type": "basetypes.StringValue"
+              }
             }
           }
         ],
@@ -502,9 +679,31 @@
           }
         },
         {
+          "name": "bool_attribute_custom_type",
+          "bool": {
+            "optional_required": "optional",
+            "custom_type": {
+              "import": "github.com/hashicorp/terraform-plugin-framework/types/basetypes",
+              "type": "basetypes.BoolType",
+              "value_type": "basetypes.BoolValue"
+            }
+          }
+        },
+        {
           "name": "float64_attribute",
           "float64": {
             "optional_required": "optional"
+          }
+        },
+        {
+          "name": "float64_attribute_custom_type",
+          "float64": {
+            "optional_required": "optional",
+            "custom_type": {
+              "import": "github.com/hashicorp/terraform-plugin-framework/types/basetypes",
+              "type": "basetypes.Float64Type",
+              "value_type": "basetypes.Float64Value"
+            }
           }
         },
         {
@@ -514,11 +713,51 @@
           }
         },
         {
+          "name": "int64_attribute_custom_type",
+          "int64": {
+            "optional_required": "optional",
+            "custom_type": {
+              "import": "github.com/hashicorp/terraform-plugin-framework/types/basetypes",
+              "type": "basetypes.Int64Type",
+              "value_type": "basetypes.Int64Value"
+            }
+          }
+        },
+        {
           "name": "list_attribute",
           "list": {
             "optional_required": "optional",
             "element_type": {
               "string": {}
+            }
+          }
+        },
+        {
+          "name": "list_attribute_custom_type",
+          "list": {
+            "optional_required": "optional",
+            "custom_type": {
+              "import": "github.com/hashicorp/terraform-plugin-framework/types/basetypes",
+              "type": "basetypes.ListType",
+              "value_type": "basetypes.ListValue"
+            },
+            "element_type": {
+              "string": {}
+            }
+          }
+        },
+        {
+          "name": "list_attribute_element_type_string_custom_type",
+          "list": {
+            "optional_required": "optional",
+            "element_type": {
+              "string": {
+                "custom_type": {
+                  "import": "github.com/hashicorp/terraform-plugin-framework/types/basetypes",
+                  "type": "basetypes.StringType",
+                  "value_type": "basetypes.StringValue"
+                }
+              }
             }
           }
         },
@@ -576,6 +815,35 @@
           }
         },
         {
+          "name": "map_attribute_custom_type",
+          "map": {
+            "optional_required": "optional",
+            "custom_type": {
+              "import": "github.com/hashicorp/terraform-plugin-framework/types/basetypes",
+              "type": "basetypes.MapType",
+              "value_type": "basetypes.MapValue"
+            },
+            "element_type": {
+              "string": {}
+            }
+          }
+        },
+        {
+          "name": "map_attribute_element_type_string_custom_type",
+          "map": {
+            "optional_required": "optional",
+            "element_type": {
+              "string": {
+                "custom_type": {
+                  "import": "github.com/hashicorp/terraform-plugin-framework/types/basetypes",
+                  "type": "basetypes.StringType",
+                  "value_type": "basetypes.StringValue"
+                }
+              }
+            }
+          }
+        },
+        {
           "name": "map_nested_bool_attribute",
           "map_nested": {
             "optional_required": "optional",
@@ -598,9 +866,55 @@
           }
         },
         {
+          "name": "number_attribute_custom_type",
+          "number": {
+            "optional_required": "optional",
+            "custom_type": {
+              "import": "github.com/hashicorp/terraform-plugin-framework/types/basetypes",
+              "type": "basetypes.NumberType",
+              "value_type": "basetypes.NumberValue"
+            }
+          }
+        },
+        {
           "name": "object_attribute",
           "object": {
             "optional_required": "optional",
+            "attribute_types": [
+              {
+                "name": "obj_string_attr",
+                "string": {}
+              }
+            ]
+          }
+        },
+        {
+          "name": "object_attribute_attribute_types_string_custom_type",
+          "object": {
+            "optional_required": "optional",
+            "attribute_types": [
+              {
+                "name": "obj_string_attr",
+                "string": {
+                  "custom_type": {
+                    "import": "github.com/hashicorp/terraform-plugin-framework/types/basetypes",
+                    "type": "basetypes.StringType",
+                    "value_type": "basetypes.StringValue"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "object_attribute_custom_type",
+          "object": {
+            "optional_required": "optional",
+            "custom_type": {
+              "import": "github.com/hashicorp/terraform-plugin-framework/types/basetypes",
+              "type": "basetypes.ObjectType",
+              "value_type": "basetypes.ObjectValue"
+            },
             "attribute_types": [
               {
                 "name": "obj_string_attr",
@@ -723,6 +1037,35 @@
           }
         },
         {
+          "name": "set_attribute_custom_type",
+          "set": {
+            "optional_required": "optional",
+            "custom_type": {
+              "import": "github.com/hashicorp/terraform-plugin-framework/types/basetypes",
+              "type": "basetypes.SetType",
+              "value_type": "basetypes.SetValue"
+            },
+            "element_type": {
+              "string": {}
+            }
+          }
+        },
+        {
+          "name": "set_attribute_element_type_string_custom_type",
+          "set": {
+            "optional_required": "optional",
+            "element_type": {
+              "string": {
+                "custom_type": {
+                  "import": "github.com/hashicorp/terraform-plugin-framework/types/basetypes",
+                  "type": "basetypes.StringType",
+                  "value_type": "basetypes.StringValue"
+                }
+              }
+            }
+          }
+        },
+        {
           "name": "set_nested_bool_attribute",
           "set_nested": {
             "optional_required": "optional",
@@ -807,6 +1150,17 @@
           "name": "string_attribute",
           "string": {
             "optional_required": "optional"
+          }
+        },
+        {
+          "name": "string_attribute_custom_type",
+          "string": {
+            "optional_required": "optional",
+            "custom_type": {
+              "import": "github.com/hashicorp/terraform-plugin-framework/types/basetypes",
+              "type": "basetypes.StringType",
+              "value_type": "basetypes.StringValue"
+            }
           }
         }
       ],
@@ -990,11 +1344,6 @@
             "name": "bool_attribute",
             "bool": {
               "computed_optional_required": "computed",
-              "custom_type": {
-                "import": "",
-                "type": "",
-                "value_type": ""
-              },
               "plan_modifiers": [
                 {
                   "requires_replace": {}
@@ -1017,6 +1366,17 @@
             }
           },
           {
+            "name": "bool_attribute_custom_type",
+            "bool": {
+              "computed_optional_required": "computed",
+              "custom_type": {
+                "import": "github.com/hashicorp/terraform-plugin-framework/types/basetypes",
+                "type": "basetypes.BoolType",
+                "value_type": "basetypes.BoolValue"
+              }
+            }
+          },
+          {
             "name": "bool_attribute_default_static",
             "bool": {
               "computed_optional_required": "optional",
@@ -1032,6 +1392,17 @@
             }
           },
           {
+            "name": "float64_attribute_custom_type",
+            "float64": {
+              "computed_optional_required": "computed",
+              "custom_type": {
+                "import": "github.com/hashicorp/terraform-plugin-framework/types/basetypes",
+                "type": "basetypes.Float64Type",
+                "value_type": "basetypes.Float64Value"
+              }
+            }
+          },
+          {
             "name": "float64_attribute_default_static",
             "float64": {
               "computed_optional_required": "optional",
@@ -1044,6 +1415,17 @@
             "name": "int64_attribute",
             "int64": {
               "computed_optional_required": "computed"
+            }
+          },
+          {
+            "name": "int64_attribute_custom_type",
+            "int64": {
+              "computed_optional_required": "computed",
+              "custom_type": {
+                "import": "github.com/hashicorp/terraform-plugin-framework/types/basetypes",
+                "type": "basetypes.Int64Type",
+                "value_type": "basetypes.Int64Value"
+              }
             }
           },
           {
@@ -1065,6 +1447,20 @@
             }
           },
           {
+            "name": "list_attribute_custom_type",
+            "list": {
+              "computed_optional_required": "computed",
+              "custom_type": {
+                "import": "github.com/hashicorp/terraform-plugin-framework/types/basetypes",
+                "type": "basetypes.ListType",
+                "value_type": "basetypes.ListValue"
+              },
+              "element_type": {
+                "string": {}
+              }
+            }
+          },
+          {
             "name": "list_attribute_default_custom",
             "list": {
               "computed_optional_required": "optional",
@@ -1076,6 +1472,21 @@
               },
               "element_type": {
                 "string": {}
+              }
+            }
+          },
+          {
+            "name": "list_attribute_element_type_string_custom_type",
+            "list": {
+              "computed_optional_required": "computed",
+              "element_type": {
+                "string": {
+                  "custom_type": {
+                    "import": "github.com/hashicorp/terraform-plugin-framework/types/basetypes",
+                    "type": "basetypes.StringType",
+                    "value_type": "basetypes.StringValue"
+                  }
+                }
               }
             }
           },
@@ -1133,6 +1544,35 @@
             }
           },
           {
+            "name": "map_attribute_custom_type",
+            "map": {
+              "computed_optional_required": "computed",
+              "custom_type": {
+                "import": "github.com/hashicorp/terraform-plugin-framework/types/basetypes",
+                "type": "basetypes.MapType",
+                "value_type": "basetypes.MapValue"
+              },
+              "element_type": {
+                "string": {}
+              }
+            }
+          },
+          {
+            "name": "map_attribute_element_type_string_custom_type",
+            "map": {
+              "computed_optional_required": "computed",
+              "element_type": {
+                "string": {
+                  "custom_type": {
+                    "import": "github.com/hashicorp/terraform-plugin-framework/types/basetypes",
+                    "type": "basetypes.StringType",
+                    "value_type": "basetypes.StringValue"
+                  }
+                }
+              }
+            }
+          },
+          {
             "name": "map_nested_bool_attribute",
             "map_nested": {
               "computed_optional_required": "computed",
@@ -1155,6 +1595,17 @@
             }
           },
           {
+            "name": "number_attribute_custom_type",
+            "number": {
+              "computed_optional_required": "computed",
+              "custom_type": {
+                "import": "github.com/hashicorp/terraform-plugin-framework/types/basetypes",
+                "type": "basetypes.NumberType",
+                "value_type": "basetypes.NumberValue"
+              }
+            }
+          },
+          {
             "name": "number_attribute_default_custom",
             "number": {
               "computed_optional_required": "optional",
@@ -1170,6 +1621,41 @@
             "name": "object_attribute",
             "object": {
               "computed_optional_required": "computed",
+              "attribute_types": [
+                {
+                  "name": "obj_string_attr",
+                  "string": {}
+                }
+              ]
+            }
+          },
+          {
+            "name": "object_attribute_attribute_types_string_custom_type",
+            "object": {
+              "computed_optional_required": "computed",
+              "attribute_types": [
+                {
+                  "name": "obj_string_attr",
+                  "string": {
+                    "custom_type": {
+                      "import": "github.com/hashicorp/terraform-plugin-framework/types/basetypes",
+                      "type": "basetypes.StringType",
+                      "value_type": "basetypes.StringValue"
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "name": "object_attribute_custom_type",
+            "object": {
+              "computed_optional_required": "computed",
+              "custom_type": {
+                "import": "github.com/hashicorp/terraform-plugin-framework/types/basetypes",
+                "type": "basetypes.ObjectType",
+                "value_type": "basetypes.ObjectValue"
+              },
               "attribute_types": [
                 {
                   "name": "obj_string_attr",
@@ -1292,6 +1778,20 @@
             }
           },
           {
+            "name": "set_attribute_custom_type",
+            "set": {
+              "computed_optional_required": "computed",
+              "custom_type": {
+                "import": "github.com/hashicorp/terraform-plugin-framework/types/basetypes",
+                "type": "basetypes.SetType",
+                "value_type": "basetypes.SetValue"
+              },
+              "element_type": {
+                "string": {}
+              }
+            }
+          },
+          {
             "name": "set_attribute_default_custom",
             "set": {
               "computed_optional_required": "optional",
@@ -1303,6 +1803,21 @@
               },
               "element_type": {
                 "string": {}
+              }
+            }
+          },
+          {
+            "name": "set_attribute_element_type_string_custom_type",
+            "set": {
+              "computed_optional_required": "computed",
+              "element_type": {
+                "string": {
+                  "custom_type": {
+                    "import": "github.com/hashicorp/terraform-plugin-framework/types/basetypes",
+                    "type": "basetypes.StringType",
+                    "value_type": "basetypes.StringValue"
+                  }
+                }
               }
             }
           },
@@ -1391,6 +1906,17 @@
             "name": "string_attribute",
             "string": {
               "computed_optional_required": "computed"
+            }
+          },
+          {
+            "name": "string_attribute_custom_type",
+            "string": {
+              "computed_optional_required": "computed",
+              "custom_type": {
+                "import": "github.com/hashicorp/terraform-plugin-framework/types/basetypes",
+                "type": "basetypes.StringType",
+                "value_type": "basetypes.StringValue"
+              }
             }
           },
           {

--- a/spec/schema.json
+++ b/spec/schema.json
@@ -354,40 +354,45 @@
             "value_type"
           ]
         },
-        "schema_bool_element": {
+        "schema_bool_type": {
           "type": "object",
-          "additionalProperties": false
+          "additionalProperties": false,
+          "properties": {
+            "custom_type": {
+              "$ref": "#/$defs/schema_custom_type"
+            }
+          }
         },
         "schema_element_type": {
           "type": "object",
           "additionalProperties": false,
           "properties": {
             "bool": {
-              "$ref": "#/$defs/schema_bool_element"
+              "$ref": "#/$defs/schema_bool_type"
             },
             "float64": {
-              "$ref": "#/$defs/schema_float64_element"
+              "$ref": "#/$defs/schema_float64_type"
             },
             "int64": {
-              "$ref": "#/$defs/schema_int64_element"
+              "$ref": "#/$defs/schema_int64_type"
             },
             "list": {
-              "$ref": "#/$defs/schema_list_element"
+              "$ref": "#/$defs/schema_list_type"
             },
             "number": {
-              "$ref": "#/$defs/schema_number_element"
+              "$ref": "#/$defs/schema_number_type"
             },
             "map": {
-              "$ref": "#/$defs/schema_map_element"
+              "$ref": "#/$defs/schema_map_type"
             },
             "object": {
-              "$ref": "#/$defs/schema_object_elements"
+              "$ref": "#/$defs/schema_object_attribute_types"
             },
             "set": {
-              "$ref": "#/$defs/schema_set_element"
+              "$ref": "#/$defs/schema_set_type"
             },
             "string": {
-              "$ref": "#/$defs/schema_string_element"
+              "$ref": "#/$defs/schema_string_type"
             }
           },
           "oneOf": [
@@ -438,44 +443,57 @@
             }
           ]
         },
-        "schema_float64_element": {
+        "schema_float64_type": {
           "type": "object",
-          "additionalProperties": false
+          "additionalProperties": false,
+          "properties": {
+            "custom_type": {
+              "$ref": "#/$defs/schema_custom_type"
+            }
+          }
         },
-        "schema_int64_element": {
+        "schema_int64_type": {
           "type": "object",
-          "additionalProperties": false
+          "additionalProperties": false,
+          "properties": {
+            "custom_type": {
+              "$ref": "#/$defs/schema_custom_type"
+            }
+          }
         },
-        "schema_list_element": {
+        "schema_list_type": {
           "type": "object",
           "additionalProperties": false,
           "properties": {
             "bool": {
-              "$ref": "#/$defs/schema_bool_element"
+              "$ref": "#/$defs/schema_bool_type"
+            },
+            "custom_type": {
+              "$ref": "#/$defs/schema_custom_type"
             },
             "float64": {
-              "$ref": "#/$defs/schema_float64_element"
+              "$ref": "#/$defs/schema_float64_type"
             },
             "int64": {
-              "$ref": "#/$defs/schema_int64_element"
+              "$ref": "#/$defs/schema_int64_type"
             },
             "list": {
-              "$ref": "#/$defs/schema_list_element"
+              "$ref": "#/$defs/schema_list_type"
             },
             "map": {
-              "$ref": "#/$defs/schema_map_element"
+              "$ref": "#/$defs/schema_map_type"
             },
             "number": {
-              "$ref": "#/$defs/schema_number_element"
+              "$ref": "#/$defs/schema_number_type"
             },
             "object": {
-              "$ref": "#/$defs/schema_object_elements"
+              "$ref": "#/$defs/schema_object_attribute_types"
             },
             "set": {
-              "$ref": "#/$defs/schema_set_element"
+              "$ref": "#/$defs/schema_set_type"
             },
             "string": {
-              "$ref": "#/$defs/schema_string_element"
+              "$ref": "#/$defs/schema_string_type"
             }
           },
           "oneOf": [
@@ -526,36 +544,39 @@
             }
           ]
         },
-        "schema_map_element": {
+        "schema_map_type": {
           "type": "object",
           "additionalProperties": false,
           "properties": {
             "bool": {
-              "$ref": "#/$defs/schema_bool_element"
+              "$ref": "#/$defs/schema_bool_type"
+            },
+            "custom_type": {
+              "$ref": "#/$defs/schema_custom_type"
             },
             "float64": {
-              "$ref": "#/$defs/schema_float64_element"
+              "$ref": "#/$defs/schema_float64_type"
             },
             "int64": {
-              "$ref": "#/$defs/schema_int64_element"
+              "$ref": "#/$defs/schema_int64_type"
             },
             "list": {
-              "$ref": "#/$defs/schema_list_element"
+              "$ref": "#/$defs/schema_list_type"
             },
             "map": {
-              "$ref": "#/$defs/schema_map_element"
+              "$ref": "#/$defs/schema_map_type"
             },
             "number": {
-              "$ref": "#/$defs/schema_number_element"
+              "$ref": "#/$defs/schema_number_type"
             },
             "object": {
-              "$ref": "#/$defs/schema_object_elements"
+              "$ref": "#/$defs/schema_object_attribute_types"
             },
             "set": {
-              "$ref": "#/$defs/schema_set_element"
+              "$ref": "#/$defs/schema_set_type"
             },
             "string": {
-              "$ref": "#/$defs/schema_string_element"
+              "$ref": "#/$defs/schema_string_type"
             }
           },
           "oneOf": [
@@ -606,18 +627,23 @@
             }
           ]
         },
-        "schema_number_element": {
+        "schema_number_type": {
           "type": "object",
-          "additionalProperties": false
+          "additionalProperties": false,
+          "properties": {
+            "custom_type": {
+              "$ref": "#/$defs/schema_custom_type"
+            }
+          }
         },
-        "schema_object_elements": {
+        "schema_object_attribute_types": {
           "type": "array",
           "minItems": 1,
           "items": {
-            "$ref": "#/$defs/schema_object_element"
+            "$ref": "#/$defs/schema_object_attribute_type"
           }
         },
-        "schema_object_element": {
+        "schema_object_attribute_type": {
           "type": "object",
           "additionalProperties": false,
           "properties": {
@@ -625,31 +651,31 @@
               "type": "string"
             },
             "bool": {
-              "$ref": "#/$defs/schema_bool_element"
+              "$ref": "#/$defs/schema_bool_type"
             },
             "float64": {
-              "$ref": "#/$defs/schema_float64_element"
+              "$ref": "#/$defs/schema_float64_type"
             },
             "int64": {
-              "$ref": "#/$defs/schema_int64_element"
+              "$ref": "#/$defs/schema_int64_type"
             },
             "list": {
-              "$ref": "#/$defs/schema_list_element"
+              "$ref": "#/$defs/schema_list_type"
             },
             "map": {
-              "$ref": "#/$defs/schema_map_element"
+              "$ref": "#/$defs/schema_map_type"
             },
             "number": {
-              "$ref": "#/$defs/schema_number_element"
+              "$ref": "#/$defs/schema_number_type"
             },
             "object": {
-              "$ref": "#/$defs/schema_object_elements"
+              "$ref": "#/$defs/schema_object_attribute_types"
             },
             "set": {
-              "$ref": "#/$defs/schema_set_element"
+              "$ref": "#/$defs/schema_set_type"
             },
             "string": {
-              "$ref": "#/$defs/schema_string_element"
+              "$ref": "#/$defs/schema_string_type"
             }
           },
           "required": [
@@ -709,36 +735,39 @@
             "required"
           ]
         },
-        "schema_set_element": {
+        "schema_set_type": {
           "type": "object",
           "additionalProperties": false,
           "properties": {
             "bool": {
-              "$ref": "#/$defs/schema_bool_element"
+              "$ref": "#/$defs/schema_bool_type"
+            },
+            "custom_type": {
+              "$ref": "#/$defs/schema_custom_type"
             },
             "float64": {
-              "$ref": "#/$defs/schema_float64_element"
+              "$ref": "#/$defs/schema_float64_type"
             },
             "int64": {
-              "$ref": "#/$defs/schema_int64_element"
+              "$ref": "#/$defs/schema_int64_type"
             },
             "list": {
-              "$ref": "#/$defs/schema_list_element"
+              "$ref": "#/$defs/schema_list_type"
             },
             "map": {
-              "$ref": "#/$defs/schema_map_element"
+              "$ref": "#/$defs/schema_map_type"
             },
             "number": {
-              "$ref": "#/$defs/schema_number_element"
+              "$ref": "#/$defs/schema_number_type"
             },
             "object": {
-              "$ref": "#/$defs/schema_object_elements"
+              "$ref": "#/$defs/schema_object_attribute_types"
             },
             "set": {
-              "$ref": "#/$defs/schema_set_element"
+              "$ref": "#/$defs/schema_set_type"
             },
             "string": {
-              "$ref": "#/$defs/schema_string_element"
+              "$ref": "#/$defs/schema_string_type"
             }
           },
           "oneOf": [
@@ -789,9 +818,14 @@
             }
           ]
         },
-        "schema_string_element": {
+        "schema_string_type": {
           "type": "object",
-          "additionalProperties": false
+          "additionalProperties": false,
+          "properties": {
+            "custom_type": {
+              "$ref": "#/$defs/schema_custom_type"
+            }
+          }
         },
     "datasource_nested_attribute_object": {
       "type": "object",
@@ -1221,7 +1255,7 @@
           "additionalProperties": false,
           "properties": {
             "attribute_types": {
-              "$ref": "#/$defs/schema_object_elements"
+              "$ref": "#/$defs/schema_object_attribute_types"
             },
             "computed_optional_required": {
               "$ref": "#/$defs/schema_computed_optional_required"
@@ -1943,7 +1977,7 @@
           "additionalProperties": false,
           "properties": {
             "attribute_types": {
-              "$ref": "#/$defs/schema_object_elements"
+              "$ref": "#/$defs/schema_object_attribute_types"
             },
             "custom_type": {
               "$ref": "#/$defs/schema_custom_type"
@@ -2726,7 +2760,7 @@
           "additionalProperties": false,
           "properties": {
             "attribute_types": {
-              "$ref": "#/$defs/schema_object_elements"
+              "$ref": "#/$defs/schema_object_attribute_types"
             },
             "computed_optional_required": {
               "$ref": "#/$defs/schema_computed_optional_required"

--- a/spec/specification_test.go
+++ b/spec/specification_test.go
@@ -79,9 +79,31 @@ func TestSpecification_JSONUnmarshal(t *testing.T) {
 									},
 								},
 								{
+									Name: "bool_attribute_custom_type",
+									Bool: &datasource.BoolAttribute{
+										ComputedOptionalRequired: schema.Computed,
+										CustomType: &schema.CustomType{
+											Import:    pointer("github.com/hashicorp/terraform-plugin-framework/types/basetypes"),
+											Type:      "basetypes.BoolType",
+											ValueType: "basetypes.BoolValue",
+										},
+									},
+								},
+								{
 									Name: "float64_attribute",
 									Float64: &datasource.Float64Attribute{
 										ComputedOptionalRequired: schema.Computed,
+									},
+								},
+								{
+									Name: "float64_attribute_custom_type",
+									Float64: &datasource.Float64Attribute{
+										ComputedOptionalRequired: schema.Computed,
+										CustomType: &schema.CustomType{
+											Import:    pointer("github.com/hashicorp/terraform-plugin-framework/types/basetypes"),
+											Type:      "basetypes.Float64Type",
+											ValueType: "basetypes.Float64Value",
+										},
 									},
 								},
 								{
@@ -91,11 +113,51 @@ func TestSpecification_JSONUnmarshal(t *testing.T) {
 									},
 								},
 								{
+									Name: "int64_attribute_custom_type",
+									Int64: &datasource.Int64Attribute{
+										ComputedOptionalRequired: schema.Computed,
+										CustomType: &schema.CustomType{
+											Import:    pointer("github.com/hashicorp/terraform-plugin-framework/types/basetypes"),
+											Type:      "basetypes.Int64Type",
+											ValueType: "basetypes.Int64Value",
+										},
+									},
+								},
+								{
 									Name: "list_attribute",
 									List: &datasource.ListAttribute{
 										ComputedOptionalRequired: schema.Computed,
 										ElementType: schema.ElementType{
 											String: &schema.StringType{},
+										},
+									},
+								},
+								{
+									Name: "list_attribute_custom_type",
+									List: &datasource.ListAttribute{
+										ComputedOptionalRequired: schema.Computed,
+										CustomType: &schema.CustomType{
+											Import:    pointer("github.com/hashicorp/terraform-plugin-framework/types/basetypes"),
+											Type:      "basetypes.ListType",
+											ValueType: "basetypes.ListValue",
+										},
+										ElementType: schema.ElementType{
+											String: &schema.StringType{},
+										},
+									},
+								},
+								{
+									Name: "list_attribute_element_type_string_custom_type",
+									List: &datasource.ListAttribute{
+										ComputedOptionalRequired: schema.Computed,
+										ElementType: schema.ElementType{
+											String: &schema.StringType{
+												CustomType: &schema.CustomType{
+													Import:    pointer("github.com/hashicorp/terraform-plugin-framework/types/basetypes"),
+													Type:      "basetypes.StringType",
+													ValueType: "basetypes.StringValue",
+												},
+											},
 										},
 									},
 								},
@@ -155,6 +217,35 @@ func TestSpecification_JSONUnmarshal(t *testing.T) {
 									},
 								},
 								{
+									Name: "map_attribute_custom_type",
+									Map: &datasource.MapAttribute{
+										ComputedOptionalRequired: schema.Computed,
+										CustomType: &schema.CustomType{
+											Import:    pointer("github.com/hashicorp/terraform-plugin-framework/types/basetypes"),
+											Type:      "basetypes.MapType",
+											ValueType: "basetypes.MapValue",
+										},
+										ElementType: schema.ElementType{
+											String: &schema.StringType{},
+										},
+									},
+								},
+								{
+									Name: "map_attribute_element_type_string_custom_type",
+									Map: &datasource.MapAttribute{
+										ComputedOptionalRequired: schema.Computed,
+										ElementType: schema.ElementType{
+											String: &schema.StringType{
+												CustomType: &schema.CustomType{
+													Import:    pointer("github.com/hashicorp/terraform-plugin-framework/types/basetypes"),
+													Type:      "basetypes.StringType",
+													ValueType: "basetypes.StringValue",
+												},
+											},
+										},
+									},
+								},
+								{
 									Name: "map_nested_bool_attribute",
 									MapNested: &datasource.MapNestedAttribute{
 										ComputedOptionalRequired: schema.Computed,
@@ -177,6 +268,17 @@ func TestSpecification_JSONUnmarshal(t *testing.T) {
 									},
 								},
 								{
+									Name: "number_attribute_custom_type",
+									Number: &datasource.NumberAttribute{
+										ComputedOptionalRequired: schema.Computed,
+										CustomType: &schema.CustomType{
+											Import:    pointer("github.com/hashicorp/terraform-plugin-framework/types/basetypes"),
+											Type:      "basetypes.NumberType",
+											ValueType: "basetypes.NumberValue",
+										},
+									},
+								},
+								{
 									Name: "object_attribute",
 									Object: &datasource.ObjectAttribute{
 										AttributeTypes: []schema.ObjectAttributeType{
@@ -186,6 +288,41 @@ func TestSpecification_JSONUnmarshal(t *testing.T) {
 											},
 										},
 										ComputedOptionalRequired: schema.Computed,
+									},
+								},
+								{
+									Name: "object_attribute_attribute_types_string_custom_type",
+									Object: &datasource.ObjectAttribute{
+										AttributeTypes: []schema.ObjectAttributeType{
+											{
+												Name: "obj_string_attr",
+												String: &schema.StringType{
+													CustomType: &schema.CustomType{
+														Import:    pointer("github.com/hashicorp/terraform-plugin-framework/types/basetypes"),
+														Type:      "basetypes.StringType",
+														ValueType: "basetypes.StringValue",
+													},
+												},
+											},
+										},
+										ComputedOptionalRequired: schema.Computed,
+									},
+								},
+								{
+									Name: "object_attribute_custom_type",
+									Object: &datasource.ObjectAttribute{
+										AttributeTypes: []schema.ObjectAttributeType{
+											{
+												Name:   "obj_string_attr",
+												String: &schema.StringType{},
+											},
+										},
+										ComputedOptionalRequired: schema.Computed,
+										CustomType: &schema.CustomType{
+											Import:    pointer("github.com/hashicorp/terraform-plugin-framework/types/basetypes"),
+											Type:      "basetypes.ObjectType",
+											ValueType: "basetypes.ObjectValue",
+										},
 									},
 								},
 								{
@@ -306,6 +443,35 @@ func TestSpecification_JSONUnmarshal(t *testing.T) {
 									},
 								},
 								{
+									Name: "set_attribute_custom_type",
+									Set: &datasource.SetAttribute{
+										ComputedOptionalRequired: schema.Computed,
+										CustomType: &schema.CustomType{
+											Import:    pointer("github.com/hashicorp/terraform-plugin-framework/types/basetypes"),
+											Type:      "basetypes.SetType",
+											ValueType: "basetypes.SetValue",
+										},
+										ElementType: schema.ElementType{
+											String: &schema.StringType{},
+										},
+									},
+								},
+								{
+									Name: "set_attribute_element_type_string_custom_type",
+									Set: &datasource.SetAttribute{
+										ComputedOptionalRequired: schema.Computed,
+										ElementType: schema.ElementType{
+											String: &schema.StringType{
+												CustomType: &schema.CustomType{
+													Import:    pointer("github.com/hashicorp/terraform-plugin-framework/types/basetypes"),
+													Type:      "basetypes.StringType",
+													ValueType: "basetypes.StringValue",
+												},
+											},
+										},
+									},
+								},
+								{
 									Name: "set_nested_bool_attribute",
 									SetNested: &datasource.SetNestedAttribute{
 										ComputedOptionalRequired: schema.Computed,
@@ -390,6 +556,17 @@ func TestSpecification_JSONUnmarshal(t *testing.T) {
 									Name: "string_attribute",
 									String: &datasource.StringAttribute{
 										ComputedOptionalRequired: schema.Computed,
+									},
+								},
+								{
+									Name: "string_attribute_custom_type",
+									String: &datasource.StringAttribute{
+										ComputedOptionalRequired: schema.Computed,
+										CustomType: &schema.CustomType{
+											Import:    pointer("github.com/hashicorp/terraform-plugin-framework/types/basetypes"),
+											Type:      "basetypes.StringType",
+											ValueType: "basetypes.StringValue",
+										},
 									},
 								},
 							},
@@ -576,9 +753,31 @@ func TestSpecification_JSONUnmarshal(t *testing.T) {
 								},
 							},
 							{
+								Name: "bool_attribute_custom_type",
+								Bool: &provider.BoolAttribute{
+									OptionalRequired: schema.Optional,
+									CustomType: &schema.CustomType{
+										Import:    pointer("github.com/hashicorp/terraform-plugin-framework/types/basetypes"),
+										Type:      "basetypes.BoolType",
+										ValueType: "basetypes.BoolValue",
+									},
+								},
+							},
+							{
 								Name: "float64_attribute",
 								Float64: &provider.Float64Attribute{
 									OptionalRequired: schema.Optional,
+								},
+							},
+							{
+								Name: "float64_attribute_custom_type",
+								Float64: &provider.Float64Attribute{
+									OptionalRequired: schema.Optional,
+									CustomType: &schema.CustomType{
+										Import:    pointer("github.com/hashicorp/terraform-plugin-framework/types/basetypes"),
+										Type:      "basetypes.Float64Type",
+										ValueType: "basetypes.Float64Value",
+									},
 								},
 							},
 							{
@@ -588,11 +787,51 @@ func TestSpecification_JSONUnmarshal(t *testing.T) {
 								},
 							},
 							{
+								Name: "int64_attribute_custom_type",
+								Int64: &provider.Int64Attribute{
+									OptionalRequired: schema.Optional,
+									CustomType: &schema.CustomType{
+										Import:    pointer("github.com/hashicorp/terraform-plugin-framework/types/basetypes"),
+										Type:      "basetypes.Int64Type",
+										ValueType: "basetypes.Int64Value",
+									},
+								},
+							},
+							{
 								Name: "list_attribute",
 								List: &provider.ListAttribute{
 									OptionalRequired: schema.Optional,
 									ElementType: schema.ElementType{
 										String: &schema.StringType{},
+									},
+								},
+							},
+							{
+								Name: "list_attribute_custom_type",
+								List: &provider.ListAttribute{
+									OptionalRequired: schema.Optional,
+									CustomType: &schema.CustomType{
+										Import:    pointer("github.com/hashicorp/terraform-plugin-framework/types/basetypes"),
+										Type:      "basetypes.ListType",
+										ValueType: "basetypes.ListValue",
+									},
+									ElementType: schema.ElementType{
+										String: &schema.StringType{},
+									},
+								},
+							},
+							{
+								Name: "list_attribute_element_type_string_custom_type",
+								List: &provider.ListAttribute{
+									OptionalRequired: schema.Optional,
+									ElementType: schema.ElementType{
+										String: &schema.StringType{
+											CustomType: &schema.CustomType{
+												Import:    pointer("github.com/hashicorp/terraform-plugin-framework/types/basetypes"),
+												Type:      "basetypes.StringType",
+												ValueType: "basetypes.StringValue",
+											},
+										},
 									},
 								},
 							},
@@ -652,6 +891,35 @@ func TestSpecification_JSONUnmarshal(t *testing.T) {
 								},
 							},
 							{
+								Name: "map_attribute_custom_type",
+								Map: &provider.MapAttribute{
+									OptionalRequired: schema.Optional,
+									CustomType: &schema.CustomType{
+										Import:    pointer("github.com/hashicorp/terraform-plugin-framework/types/basetypes"),
+										Type:      "basetypes.MapType",
+										ValueType: "basetypes.MapValue",
+									},
+									ElementType: schema.ElementType{
+										String: &schema.StringType{},
+									},
+								},
+							},
+							{
+								Name: "map_attribute_element_type_string_custom_type",
+								Map: &provider.MapAttribute{
+									OptionalRequired: schema.Optional,
+									ElementType: schema.ElementType{
+										String: &schema.StringType{
+											CustomType: &schema.CustomType{
+												Import:    pointer("github.com/hashicorp/terraform-plugin-framework/types/basetypes"),
+												Type:      "basetypes.StringType",
+												ValueType: "basetypes.StringValue",
+											},
+										},
+									},
+								},
+							},
+							{
 								Name: "map_nested_bool_attribute",
 								MapNested: &provider.MapNestedAttribute{
 									OptionalRequired: schema.Optional,
@@ -674,6 +942,17 @@ func TestSpecification_JSONUnmarshal(t *testing.T) {
 								},
 							},
 							{
+								Name: "number_attribute_custom_type",
+								Number: &provider.NumberAttribute{
+									OptionalRequired: schema.Optional,
+									CustomType: &schema.CustomType{
+										Import:    pointer("github.com/hashicorp/terraform-plugin-framework/types/basetypes"),
+										Type:      "basetypes.NumberType",
+										ValueType: "basetypes.NumberValue",
+									},
+								},
+							},
+							{
 								Name: "object_attribute",
 								Object: &provider.ObjectAttribute{
 									AttributeTypes: []schema.ObjectAttributeType{
@@ -683,6 +962,41 @@ func TestSpecification_JSONUnmarshal(t *testing.T) {
 										},
 									},
 									OptionalRequired: schema.Optional,
+								},
+							},
+							{
+								Name: "object_attribute_attribute_types_string_custom_type",
+								Object: &provider.ObjectAttribute{
+									AttributeTypes: []schema.ObjectAttributeType{
+										{
+											Name: "obj_string_attr",
+											String: &schema.StringType{
+												CustomType: &schema.CustomType{
+													Import:    pointer("github.com/hashicorp/terraform-plugin-framework/types/basetypes"),
+													Type:      "basetypes.StringType",
+													ValueType: "basetypes.StringValue",
+												},
+											},
+										},
+									},
+									OptionalRequired: schema.Optional,
+								},
+							},
+							{
+								Name: "object_attribute_custom_type",
+								Object: &provider.ObjectAttribute{
+									AttributeTypes: []schema.ObjectAttributeType{
+										{
+											Name:   "obj_string_attr",
+											String: &schema.StringType{},
+										},
+									},
+									OptionalRequired: schema.Optional,
+									CustomType: &schema.CustomType{
+										Import:    pointer("github.com/hashicorp/terraform-plugin-framework/types/basetypes"),
+										Type:      "basetypes.ObjectType",
+										ValueType: "basetypes.ObjectValue",
+									},
 								},
 							},
 							{
@@ -803,6 +1117,35 @@ func TestSpecification_JSONUnmarshal(t *testing.T) {
 								},
 							},
 							{
+								Name: "set_attribute_custom_type",
+								Set: &provider.SetAttribute{
+									OptionalRequired: schema.Optional,
+									CustomType: &schema.CustomType{
+										Import:    pointer("github.com/hashicorp/terraform-plugin-framework/types/basetypes"),
+										Type:      "basetypes.SetType",
+										ValueType: "basetypes.SetValue",
+									},
+									ElementType: schema.ElementType{
+										String: &schema.StringType{},
+									},
+								},
+							},
+							{
+								Name: "set_attribute_element_type_string_custom_type",
+								Set: &provider.SetAttribute{
+									OptionalRequired: schema.Optional,
+									ElementType: schema.ElementType{
+										String: &schema.StringType{
+											CustomType: &schema.CustomType{
+												Import:    pointer("github.com/hashicorp/terraform-plugin-framework/types/basetypes"),
+												Type:      "basetypes.StringType",
+												ValueType: "basetypes.StringValue",
+											},
+										},
+									},
+								},
+							},
+							{
 								Name: "set_nested_bool_attribute",
 								SetNested: &provider.SetNestedAttribute{
 									OptionalRequired: schema.Optional,
@@ -887,6 +1230,17 @@ func TestSpecification_JSONUnmarshal(t *testing.T) {
 								Name: "string_attribute",
 								String: &provider.StringAttribute{
 									OptionalRequired: schema.Optional,
+								},
+							},
+							{
+								Name: "string_attribute_custom_type",
+								String: &provider.StringAttribute{
+									OptionalRequired: schema.Optional,
+									CustomType: &schema.CustomType{
+										Import:    pointer("github.com/hashicorp/terraform-plugin-framework/types/basetypes"),
+										Type:      "basetypes.StringType",
+										ValueType: "basetypes.StringValue",
+									},
 								},
 							},
 						},
@@ -1070,11 +1424,6 @@ func TestSpecification_JSONUnmarshal(t *testing.T) {
 									Name: "bool_attribute",
 									Bool: &resource.BoolAttribute{
 										ComputedOptionalRequired: schema.Computed,
-										CustomType: &schema.CustomType{
-											Import:    pointer(""),
-											Type:      "",
-											ValueType: "",
-										},
 										PlanModifiers: []schema.BoolPlanModifier{
 											{},
 											{
@@ -1095,6 +1444,17 @@ func TestSpecification_JSONUnmarshal(t *testing.T) {
 									},
 								},
 								{
+									Name: "bool_attribute_custom_type",
+									Bool: &resource.BoolAttribute{
+										ComputedOptionalRequired: schema.Computed,
+										CustomType: &schema.CustomType{
+											Import:    pointer("github.com/hashicorp/terraform-plugin-framework/types/basetypes"),
+											Type:      "basetypes.BoolType",
+											ValueType: "basetypes.BoolValue",
+										},
+									},
+								},
+								{
 									Name: "bool_attribute_default_static",
 									Bool: &resource.BoolAttribute{
 										ComputedOptionalRequired: schema.Optional,
@@ -1110,6 +1470,17 @@ func TestSpecification_JSONUnmarshal(t *testing.T) {
 									},
 								},
 								{
+									Name: "float64_attribute_custom_type",
+									Float64: &resource.Float64Attribute{
+										ComputedOptionalRequired: schema.Computed,
+										CustomType: &schema.CustomType{
+											Import:    pointer("github.com/hashicorp/terraform-plugin-framework/types/basetypes"),
+											Type:      "basetypes.Float64Type",
+											ValueType: "basetypes.Float64Value",
+										},
+									},
+								},
+								{
 									Name: "float64_attribute_default_static",
 									Float64: &resource.Float64Attribute{
 										ComputedOptionalRequired: schema.Optional,
@@ -1122,6 +1493,17 @@ func TestSpecification_JSONUnmarshal(t *testing.T) {
 									Name: "int64_attribute",
 									Int64: &resource.Int64Attribute{
 										ComputedOptionalRequired: schema.Computed,
+									},
+								},
+								{
+									Name: "int64_attribute_custom_type",
+									Int64: &resource.Int64Attribute{
+										ComputedOptionalRequired: schema.Computed,
+										CustomType: &schema.CustomType{
+											Import:    pointer("github.com/hashicorp/terraform-plugin-framework/types/basetypes"),
+											Type:      "basetypes.Int64Type",
+											ValueType: "basetypes.Int64Value",
+										},
 									},
 								},
 								{
@@ -1143,6 +1525,20 @@ func TestSpecification_JSONUnmarshal(t *testing.T) {
 									},
 								},
 								{
+									Name: "list_attribute_custom_type",
+									List: &resource.ListAttribute{
+										ComputedOptionalRequired: schema.Computed,
+										CustomType: &schema.CustomType{
+											Import:    pointer("github.com/hashicorp/terraform-plugin-framework/types/basetypes"),
+											Type:      "basetypes.ListType",
+											ValueType: "basetypes.ListValue",
+										},
+										ElementType: schema.ElementType{
+											String: &schema.StringType{},
+										},
+									},
+								},
+								{
 									Name: "list_attribute_default_custom",
 									List: &resource.ListAttribute{
 										ComputedOptionalRequired: schema.Optional,
@@ -1154,6 +1550,21 @@ func TestSpecification_JSONUnmarshal(t *testing.T) {
 										},
 										ElementType: schema.ElementType{
 											String: &schema.StringType{},
+										},
+									},
+								},
+								{
+									Name: "list_attribute_element_type_string_custom_type",
+									List: &resource.ListAttribute{
+										ComputedOptionalRequired: schema.Computed,
+										ElementType: schema.ElementType{
+											String: &schema.StringType{
+												CustomType: &schema.CustomType{
+													Import:    pointer("github.com/hashicorp/terraform-plugin-framework/types/basetypes"),
+													Type:      "basetypes.StringType",
+													ValueType: "basetypes.StringValue",
+												},
+											},
 										},
 									},
 								},
@@ -1213,6 +1624,35 @@ func TestSpecification_JSONUnmarshal(t *testing.T) {
 									},
 								},
 								{
+									Name: "map_attribute_custom_type",
+									Map: &resource.MapAttribute{
+										ComputedOptionalRequired: schema.Computed,
+										CustomType: &schema.CustomType{
+											Import:    pointer("github.com/hashicorp/terraform-plugin-framework/types/basetypes"),
+											Type:      "basetypes.MapType",
+											ValueType: "basetypes.MapValue",
+										},
+										ElementType: schema.ElementType{
+											String: &schema.StringType{},
+										},
+									},
+								},
+								{
+									Name: "map_attribute_element_type_string_custom_type",
+									Map: &resource.MapAttribute{
+										ComputedOptionalRequired: schema.Computed,
+										ElementType: schema.ElementType{
+											String: &schema.StringType{
+												CustomType: &schema.CustomType{
+													Import:    pointer("github.com/hashicorp/terraform-plugin-framework/types/basetypes"),
+													Type:      "basetypes.StringType",
+													ValueType: "basetypes.StringValue",
+												},
+											},
+										},
+									},
+								},
+								{
 									Name: "map_nested_bool_attribute",
 									MapNested: &resource.MapNestedAttribute{
 										ComputedOptionalRequired: schema.Computed,
@@ -1232,6 +1672,17 @@ func TestSpecification_JSONUnmarshal(t *testing.T) {
 									Name: "number_attribute",
 									Number: &resource.NumberAttribute{
 										ComputedOptionalRequired: schema.Computed,
+									},
+								},
+								{
+									Name: "number_attribute_custom_type",
+									Number: &resource.NumberAttribute{
+										ComputedOptionalRequired: schema.Computed,
+										CustomType: &schema.CustomType{
+											Import:    pointer("github.com/hashicorp/terraform-plugin-framework/types/basetypes"),
+											Type:      "basetypes.NumberType",
+											ValueType: "basetypes.NumberValue",
+										},
 									},
 								},
 								{
@@ -1256,6 +1707,41 @@ func TestSpecification_JSONUnmarshal(t *testing.T) {
 											},
 										},
 										ComputedOptionalRequired: schema.Computed,
+									},
+								},
+								{
+									Name: "object_attribute_attribute_types_string_custom_type",
+									Object: &resource.ObjectAttribute{
+										AttributeTypes: []schema.ObjectAttributeType{
+											{
+												Name: "obj_string_attr",
+												String: &schema.StringType{
+													CustomType: &schema.CustomType{
+														Import:    pointer("github.com/hashicorp/terraform-plugin-framework/types/basetypes"),
+														Type:      "basetypes.StringType",
+														ValueType: "basetypes.StringValue",
+													},
+												},
+											},
+										},
+										ComputedOptionalRequired: schema.Computed,
+									},
+								},
+								{
+									Name: "object_attribute_custom_type",
+									Object: &resource.ObjectAttribute{
+										AttributeTypes: []schema.ObjectAttributeType{
+											{
+												Name:   "obj_string_attr",
+												String: &schema.StringType{},
+											},
+										},
+										ComputedOptionalRequired: schema.Computed,
+										CustomType: &schema.CustomType{
+											Import:    pointer("github.com/hashicorp/terraform-plugin-framework/types/basetypes"),
+											Type:      "basetypes.ObjectType",
+											ValueType: "basetypes.ObjectValue",
+										},
 									},
 								},
 								{
@@ -1376,6 +1862,20 @@ func TestSpecification_JSONUnmarshal(t *testing.T) {
 									},
 								},
 								{
+									Name: "set_attribute_custom_type",
+									Set: &resource.SetAttribute{
+										ComputedOptionalRequired: schema.Computed,
+										CustomType: &schema.CustomType{
+											Import:    pointer("github.com/hashicorp/terraform-plugin-framework/types/basetypes"),
+											Type:      "basetypes.SetType",
+											ValueType: "basetypes.SetValue",
+										},
+										ElementType: schema.ElementType{
+											String: &schema.StringType{},
+										},
+									},
+								},
+								{
 									Name: "set_attribute_default_custom",
 									Set: &resource.SetAttribute{
 										ComputedOptionalRequired: schema.Optional,
@@ -1387,6 +1887,21 @@ func TestSpecification_JSONUnmarshal(t *testing.T) {
 										},
 										ElementType: schema.ElementType{
 											String: &schema.StringType{},
+										},
+									},
+								},
+								{
+									Name: "set_attribute_element_type_string_custom_type",
+									Set: &resource.SetAttribute{
+										ComputedOptionalRequired: schema.Computed,
+										ElementType: schema.ElementType{
+											String: &schema.StringType{
+												CustomType: &schema.CustomType{
+													Import:    pointer("github.com/hashicorp/terraform-plugin-framework/types/basetypes"),
+													Type:      "basetypes.StringType",
+													ValueType: "basetypes.StringValue",
+												},
+											},
 										},
 									},
 								},
@@ -1475,6 +1990,17 @@ func TestSpecification_JSONUnmarshal(t *testing.T) {
 									Name: "string_attribute",
 									String: &resource.StringAttribute{
 										ComputedOptionalRequired: schema.Computed,
+									},
+								},
+								{
+									Name: "string_attribute_custom_type",
+									String: &resource.StringAttribute{
+										ComputedOptionalRequired: schema.Computed,
+										CustomType: &schema.CustomType{
+											Import:    pointer("github.com/hashicorp/terraform-plugin-framework/types/basetypes"),
+											Type:      "basetypes.StringType",
+											ValueType: "basetypes.StringValue",
+										},
 									},
 								},
 								{


### PR DESCRIPTION
Provider developers should have the ability to customize the schema/value types underlying structural or collection types. Added specification testing coverage for pre-existing attribute type customization support and new type customization support.
