### PR TITLE
Refine various object required properties

### DIFF
--- a/spec/schema.json
+++ b/spec/schema.json
@@ -49,17 +49,8 @@
           "$ref": "#/$defs/datasource_blocks"
         }
       },
-      "anyOf": [
-        {
-          "required": [
-            "attributes"
-          ]
-        },
-        {
-          "required": [
-            "blocks"
-          ]
-        }
+      "required": [
+        "attributes"
       ]
     },
     "datasource_attributes": {
@@ -238,17 +229,8 @@
           "$ref": "#/$defs/resource_blocks"
         }
       },
-      "anyOf": [
-        {
-          "required": [
-            "attributes"
-          ]
-        },
-        {
-          "required": [
-            "blocks"
-          ]
-        }
+      "required": [
+        "attributes"
       ]
     },
     "resource_attributes": {
@@ -349,7 +331,6 @@
             }
           },
           "required": [
-            "import",
             "type",
             "value_type"
           ]
@@ -839,10 +820,7 @@
         "validators": {
           "$ref": "#/$defs/schema_object_validators"
         }
-      },
-      "required": [
-        "attributes"
-      ]
+      }
     },
     "datasource_nested_block_object": {
       "type": "object",
@@ -859,19 +837,7 @@
         "validators": {
           "$ref": "#/$defs/schema_object_validators"
         }
-      },
-      "anyOf": [
-        {
-          "required": [
-            "attributes"
-          ]
-        },
-        {
-          "required": [
-            "blocks"
-          ]
-        }
-      ]
+      }
     },
     "datasource_bool_attribute": {
       "type": "object",
@@ -1489,7 +1455,6 @@
             }
           },
           "required": [
-            "attributes",
             "computed_optional_required"
           ]
         }
@@ -1529,19 +1494,7 @@
             "validators": {
               "$ref": "#/$defs/schema_object_validators"
             }
-          },
-          "anyOf": [
-            {
-              "required": [
-                "attributes"
-              ]
-            },
-            {
-              "required": [
-                "blocks"
-              ]
-            }
-          ]
+          }
         }
       },
       "required": [
@@ -1561,10 +1514,7 @@
         "validators": {
           "$ref": "#/$defs/schema_object_validators"
         }
-      },
-      "required": [
-        "attributes"
-      ]
+      }
     },
     "provider_nested_block_object": {
       "type": "object",
@@ -1581,19 +1531,7 @@
         "validators": {
           "$ref": "#/$defs/schema_object_validators"
         }
-      },
-      "anyOf": [
-        {
-          "required": [
-            "attributes"
-          ]
-        },
-        {
-          "required": [
-            "blocks"
-          ]
-        }
-      ]
+      }
     },
     "provider_bool_attribute": {
       "type": "object",
@@ -2172,7 +2110,6 @@
             }
           },
           "required": [
-            "attributes",
             "optional_required"
           ]
         }
@@ -2212,19 +2149,7 @@
             "validators": {
               "$ref": "#/$defs/schema_object_validators"
             }
-          },
-          "anyOf": [
-            {
-              "required": [
-                "attributes"
-              ]
-            },
-            {
-              "required": [
-                "blocks"
-              ]
-            }
-          ]
+          }
         }
       },
       "required": [
@@ -2286,10 +2211,7 @@
         "validators": {
           "$ref": "#/$defs/schema_object_validators"
         }
-      },
-      "required": [
-        "attributes"
-      ]
+      }
     },
     "resource_nested_block_object": {
       "type": "object",
@@ -2309,19 +2231,7 @@
         "validators": {
           "$ref": "#/$defs/schema_object_validators"
         }
-      },
-      "anyOf": [
-        {
-          "required": [
-            "attributes"
-          ]
-        },
-        {
-          "required": [
-            "blocks"
-          ]
-        }
-      ]
+      }
     },
     "resource_bool_attribute": {
       "type": "object",
@@ -2985,7 +2895,6 @@
             }
           },
           "required": [
-            "attributes",
             "computed_optional_required"
           ]
         }
@@ -3031,19 +2940,7 @@
             "validators": {
               "$ref": "#/$defs/schema_object_validators"
             }
-          },
-          "anyOf": [
-            {
-              "required": [
-                "attributes"
-              ]
-            },
-            {
-              "required": [
-                "blocks"
-              ]
-            }
-          ]
+          }
         }
       },
       "required": [


### PR DESCRIPTION
This changeset modifies the JSON schema `required` property in various objects:

- `#/$defs/datasource_schema` attribute or block requirement: Datasources can be technically be created without either, however to generally be useful a data source should always have at least have one attribute for referencing elsewhere. It is extremely unlikely that a real world datasource would contain blocks, but no top level attributes.
- `#/$defs/*_nested_attribute_object` / `#/$defs/*_single_nested_attribute` attributes requirement: A nested object may be configurable as an empty object (`{}`) to match its API, which should be allowed rather than developers thinking they need to switch to a list/map/set of (empty) object type or figure out that an empty attributes array will validate correctly.
- `#/$defs/*_nested_block_object` / `#/$defs/*_single_nested_block` attributes or blocks requirement: A nested object may be configurable as an empty object (`{}`) to match its API, which should be allowed rather than developers figuring out that an empty attributes or blocks array will validate correctly.
- `#/$defs/resource_schema` attribute or block requirement: Resources can be technically be created without either, however to generally be useful a resource should always have at least have one identifying attribute for refresh. It is extremely unlikely that a real world resource would contain blocks, but no top level attributes.
- `#/$defs/schema_custom_type` import requirement. Provider code should be definable with custom types that are declared in the same package as the generation, therefore making an external import unnecessary. The Go bindings already account for this being optionally defined and this matches the implementation of custom defaults, plan modifiers, and validators.