### PR TITLE
spec: Add ObjectType with CustomType

### DIFF
--- a/datasource/attribute_test.go
+++ b/datasource/attribute_test.go
@@ -247,12 +247,14 @@ func TestAttributes_Validate(t *testing.T) {
 						AttributeTypes: schema.ObjectAttributeTypes{
 							{
 								Name: "obj_attr_one",
-								Object: schema.ObjectAttributeTypes{
-									{
-										Name: "nested_obj_attr_one",
-									},
-									{
-										Name: "nested_obj_attr_one",
+								Object: &schema.ObjectType{
+									AttributeTypes: schema.ObjectAttributeTypes{
+										{
+											Name: "nested_obj_attr_one",
+										},
+										{
+											Name: "nested_obj_attr_one",
+										},
 									},
 								},
 							},

--- a/provider/attribute_test.go
+++ b/provider/attribute_test.go
@@ -247,12 +247,14 @@ func TestAttributes_Validate(t *testing.T) {
 						AttributeTypes: schema.ObjectAttributeTypes{
 							{
 								Name: "obj_attr_one",
-								Object: schema.ObjectAttributeTypes{
-									{
-										Name: "nested_obj_attr_one",
-									},
-									{
-										Name: "nested_obj_attr_one",
+								Object: &schema.ObjectType{
+									AttributeTypes: schema.ObjectAttributeTypes{
+										{
+											Name: "nested_obj_attr_one",
+										},
+										{
+											Name: "nested_obj_attr_one",
+										},
 									},
 								},
 							},

--- a/resource/attribute_test.go
+++ b/resource/attribute_test.go
@@ -247,12 +247,14 @@ func TestAttributes_Validate(t *testing.T) {
 						AttributeTypes: schema.ObjectAttributeTypes{
 							{
 								Name: "obj_attr_one",
-								Object: schema.ObjectAttributeTypes{
-									{
-										Name: "nested_obj_attr_one",
-									},
-									{
-										Name: "nested_obj_attr_one",
+								Object: &schema.ObjectType{
+									AttributeTypes: schema.ObjectAttributeTypes{
+										{
+											Name: "nested_obj_attr_one",
+										},
+										{
+											Name: "nested_obj_attr_one",
+										},
 									},
 								},
 							},

--- a/schema/element_type.go
+++ b/schema/element_type.go
@@ -4,13 +4,13 @@
 package schema
 
 type ElementType struct {
-	Bool    *BoolType             `json:"bool,omitempty"`
-	Float64 *Float64Type          `json:"float64,omitempty"`
-	Int64   *Int64Type            `json:"int64,omitempty"`
-	List    *ListType             `json:"list,omitempty"`
-	Map     *MapType              `json:"map,omitempty"`
-	Number  *NumberType           `json:"number,omitempty"`
-	Object  []ObjectAttributeType `json:"object,omitempty"`
-	Set     *SetType              `json:"set,omitempty"`
-	String  *StringType           `json:"string,omitempty"`
+	Bool    *BoolType    `json:"bool,omitempty"`
+	Float64 *Float64Type `json:"float64,omitempty"`
+	Int64   *Int64Type   `json:"int64,omitempty"`
+	List    *ListType    `json:"list,omitempty"`
+	Map     *MapType     `json:"map,omitempty"`
+	Number  *NumberType  `json:"number,omitempty"`
+	Object  *ObjectType  `json:"object,omitempty"`
+	Set     *SetType     `json:"set,omitempty"`
+	String  *StringType  `json:"string,omitempty"`
 }

--- a/schema/object_attribute_type.go
+++ b/schema/object_attribute_type.go
@@ -12,15 +12,15 @@ import (
 type ObjectAttributeType struct {
 	Name string `json:"name"`
 
-	Bool    *BoolType            `json:"bool,omitempty"`
-	Float64 *Float64Type         `json:"float64,omitempty"`
-	Int64   *Int64Type           `json:"int64,omitempty"`
-	List    *ListType            `json:"list,omitempty"`
-	Map     *MapType             `json:"map,omitempty"`
-	Number  *NumberType          `json:"number,omitempty"`
-	Object  ObjectAttributeTypes `json:"object,omitempty"`
-	Set     *SetType             `json:"set,omitempty"`
-	String  *StringType          `json:"string,omitempty"`
+	Bool    *BoolType    `json:"bool,omitempty"`
+	Float64 *Float64Type `json:"float64,omitempty"`
+	Int64   *Int64Type   `json:"int64,omitempty"`
+	List    *ListType    `json:"list,omitempty"`
+	Map     *MapType     `json:"map,omitempty"`
+	Number  *NumberType  `json:"number,omitempty"`
+	Object  *ObjectType  `json:"object,omitempty"`
+	Set     *SetType     `json:"set,omitempty"`
+	String  *StringType  `json:"string,omitempty"`
 }
 
 type ObjectValidateRequest struct {
@@ -46,7 +46,7 @@ func (o ObjectAttributeTypes) Validate(ctx context.Context, req ObjectValidateRe
 				Path: fmt.Sprintf("%s object attribute type %q", req.Path, attributeType.Name),
 			}
 
-			err := attributeType.Object.Validate(ctx, objectValidateRequest)
+			err := attributeType.Object.AttributeTypes.Validate(ctx, objectValidateRequest)
 
 			nestedErrs = errors.Join(nestedErrs, err)
 		}

--- a/schema/object_type.go
+++ b/schema/object_type.go
@@ -1,0 +1,11 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package schema
+
+type ObjectType struct {
+	AttributeTypes ObjectAttributeTypes `json:"attribute_types"`
+
+	// CustomType is a customization of the ObjectType.
+	CustomType *CustomType `json:"custom_type,omitempty"`
+}

--- a/spec/example.json
+++ b/spec/example.json
@@ -109,12 +109,14 @@
             "list": {
               "computed_optional_required": "computed",
               "element_type": {
-                "object": [
-                  {
-                    "name": "obj_string_attr",
-                    "string": {}
-                  }
-                ]
+                "object": {
+                  "attribute_types": [
+                    {
+                      "name": "obj_string_attr",
+                      "string": {}
+                    }
+                  ]
+                }
               }
             }
           },
@@ -123,17 +125,21 @@
             "list": {
               "computed_optional_required": "computed",
               "element_type": {
-                "object": [
-                  {
-                    "name": "obj_obj_attr",
-                    "object": [
-                      {
-                        "name": "obj_obj_string_attr",
-                        "string": {}
+                "object": {
+                  "attribute_types": [
+                    {
+                      "name": "obj_obj_attr",
+                      "object": {
+                        "attribute_types": [
+                          {
+                            "name": "obj_obj_string_attr",
+                            "string": {}
+                          }
+                        ]
                       }
-                    ]
-                  }
-                ]
+                    }
+                  ]
+                }
               }
             }
           },
@@ -221,6 +227,30 @@
             }
           },
           {
+            "name": "object_attribute_attribute_types_object_custom_type",
+            "object": {
+              "computed_optional_required": "computed",
+              "attribute_types": [
+                {
+                  "name": "obj_object_attr",
+                  "object": {
+                    "attribute_types": [
+                      {
+                        "name": "obj_object_string_attr",
+                        "string": {}
+                      }
+                    ],
+                    "custom_type": {
+                      "import": "github.com/hashicorp/terraform-plugin-framework/types/basetypes",
+                      "type": "basetypes.ObjectType",
+                      "value_type": "basetypes.ObjectValue"
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          {
             "name": "object_attribute_attribute_types_string_custom_type",
             "object": {
               "computed_optional_required": "computed",
@@ -277,12 +307,14 @@
                 {
                   "name": "obj_list_attr",
                   "list": {
-                    "object": [
-                      {
-                        "name": "obj_list_obj_attr",
-                        "string": {}
-                      }
-                    ]
+                    "object": {
+                      "attribute_types": [
+                        {
+                          "name": "obj_list_obj_attr",
+                          "string": {}
+                        }
+                      ]
+                    }
                   }
                 }
               ]
@@ -777,12 +809,14 @@
           "list": {
             "optional_required": "optional",
             "element_type": {
-              "object": [
-                {
-                  "name": "obj_string_attr",
-                  "string": {}
-                }
-              ]
+              "object": {
+                "attribute_types": [
+                  {
+                    "name": "obj_string_attr",
+                    "string": {}
+                  }
+                ]
+              }
             }
           }
         },
@@ -791,17 +825,21 @@
           "list": {
             "optional_required": "optional",
             "element_type": {
-              "object": [
-                {
-                  "name": "obj_obj_attr",
-                  "object": [
-                    {
-                      "name": "obj_obj_string_attr",
-                      "string": {}
+              "object": {
+                "attribute_types": [
+                  {
+                    "name": "obj_obj_attr",
+                    "object": {
+                      "attribute_types": [
+                        {
+                          "name": "obj_obj_string_attr",
+                          "string": {}
+                        }
+                      ]
                     }
-                  ]
-                }
-              ]
+                  }
+                ]
+              }
             }
           }
         },
@@ -889,6 +927,30 @@
           }
         },
         {
+          "name": "object_attribute_attribute_types_object_custom_type",
+          "object": {
+            "optional_required": "optional",
+            "attribute_types": [
+              {
+                "name": "obj_object_attr",
+                "object": {
+                  "attribute_types": [
+                    {
+                      "name": "obj_object_string_attr",
+                      "string": {}
+                    }
+                  ],
+                  "custom_type": {
+                    "import": "github.com/hashicorp/terraform-plugin-framework/types/basetypes",
+                    "type": "basetypes.ObjectType",
+                    "value_type": "basetypes.ObjectValue"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
           "name": "object_attribute_attribute_types_string_custom_type",
           "object": {
             "optional_required": "optional",
@@ -945,12 +1007,14 @@
               {
                 "name": "obj_list_attr",
                 "list": {
-                  "object": [
-                    {
-                      "name": "obj_list_obj_attr",
-                      "string": {}
-                    }
-                  ]
+                  "object": {
+                    "attribute_types": [
+                      {
+                        "name": "obj_list_obj_attr",
+                        "string": {}
+                      }
+                    ]
+                  }
                 }
               }
             ]
@@ -1506,12 +1570,14 @@
             "list": {
               "computed_optional_required": "computed",
               "element_type": {
-                "object": [
-                  {
-                    "name": "obj_string_attr",
-                    "string": {}
-                  }
-                ]
+                "object": {
+                  "attribute_types": [
+                    {
+                      "name": "obj_string_attr",
+                      "string": {}
+                    }
+                  ]
+                }
               }
             }
           },
@@ -1520,17 +1586,21 @@
             "list": {
               "computed_optional_required": "computed",
               "element_type": {
-                "object": [
-                  {
-                    "name": "obj_obj_attr",
-                    "object": [
-                      {
-                        "name": "obj_obj_string_attr",
-                        "string": {}
+                "object": {
+                  "attribute_types": [
+                    {
+                      "name": "obj_obj_attr",
+                      "object": {
+                        "attribute_types": [
+                          {
+                            "name": "obj_obj_string_attr",
+                            "string": {}
+                          }
+                        ]
                       }
-                    ]
-                  }
-                ]
+                    }
+                  ]
+                }
               }
             }
           },
@@ -1630,6 +1700,30 @@
             }
           },
           {
+            "name": "object_attribute_attribute_types_object_custom_type",
+            "object": {
+              "computed_optional_required": "computed",
+              "attribute_types": [
+                {
+                  "name": "obj_object_attr",
+                  "object": {
+                    "attribute_types": [
+                      {
+                        "name": "obj_object_string_attr",
+                        "string": {}
+                      }
+                    ],
+                    "custom_type": {
+                      "import": "github.com/hashicorp/terraform-plugin-framework/types/basetypes",
+                      "type": "basetypes.ObjectType",
+                      "value_type": "basetypes.ObjectValue"
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          {
             "name": "object_attribute_attribute_types_string_custom_type",
             "object": {
               "computed_optional_required": "computed",
@@ -1686,12 +1780,14 @@
                 {
                   "name": "obj_list_attr",
                   "list": {
-                    "object": [
-                      {
-                        "name": "obj_list_obj_attr",
-                        "string": {}
-                      }
-                    ]
+                    "object": {
+                      "attribute_types": [
+                        {
+                          "name": "obj_list_obj_attr",
+                          "string": {}
+                        }
+                      ]
+                    }
                   }
                 }
               ]

--- a/spec/schema.json
+++ b/spec/schema.json
@@ -367,7 +367,7 @@
               "$ref": "#/$defs/schema_map_type"
             },
             "object": {
-              "$ref": "#/$defs/schema_object_attribute_types"
+              "$ref": "#/$defs/schema_object_type"
             },
             "set": {
               "$ref": "#/$defs/schema_set_type"
@@ -468,7 +468,7 @@
               "$ref": "#/$defs/schema_number_type"
             },
             "object": {
-              "$ref": "#/$defs/schema_object_attribute_types"
+              "$ref": "#/$defs/schema_object_type"
             },
             "set": {
               "$ref": "#/$defs/schema_set_type"
@@ -551,7 +551,7 @@
               "$ref": "#/$defs/schema_number_type"
             },
             "object": {
-              "$ref": "#/$defs/schema_object_attribute_types"
+              "$ref": "#/$defs/schema_object_type"
             },
             "set": {
               "$ref": "#/$defs/schema_set_type"
@@ -650,7 +650,7 @@
               "$ref": "#/$defs/schema_number_type"
             },
             "object": {
-              "$ref": "#/$defs/schema_object_attribute_types"
+              "$ref": "#/$defs/schema_object_type"
             },
             "set": {
               "$ref": "#/$defs/schema_set_type"
@@ -710,6 +710,18 @@
             }
           ]
         },
+        "schema_object_type": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "attribute_types": {
+              "$ref": "#/$defs/schema_object_attribute_types"
+            },
+            "custom_type": {
+              "$ref": "#/$defs/schema_custom_type"
+            }
+          }
+        },
         "schema_optional_required": {
           "enum": [
             "optional",
@@ -742,7 +754,7 @@
               "$ref": "#/$defs/schema_number_type"
             },
             "object": {
-              "$ref": "#/$defs/schema_object_attribute_types"
+              "$ref": "#/$defs/schema_object_type"
             },
             "set": {
               "$ref": "#/$defs/schema_set_type"

--- a/spec/specification_test.go
+++ b/spec/specification_test.go
@@ -185,10 +185,12 @@ func TestSpecification_JSONUnmarshal(t *testing.T) {
 									List: &datasource.ListAttribute{
 										ComputedOptionalRequired: schema.Computed,
 										ElementType: schema.ElementType{
-											Object: []schema.ObjectAttributeType{
-												{
-													Name:   "obj_string_attr",
-													String: &schema.StringType{},
+											Object: &schema.ObjectType{
+												AttributeTypes: []schema.ObjectAttributeType{
+													{
+														Name:   "obj_string_attr",
+														String: &schema.StringType{},
+													},
 												},
 											},
 										},
@@ -199,13 +201,17 @@ func TestSpecification_JSONUnmarshal(t *testing.T) {
 									List: &datasource.ListAttribute{
 										ComputedOptionalRequired: schema.Computed,
 										ElementType: schema.ElementType{
-											Object: []schema.ObjectAttributeType{
-												{
-													Name: "obj_obj_attr",
-													Object: []schema.ObjectAttributeType{
-														{
-															Name:   "obj_obj_string_attr",
-															String: &schema.StringType{},
+											Object: &schema.ObjectType{
+												AttributeTypes: []schema.ObjectAttributeType{
+													{
+														Name: "obj_obj_attr",
+														Object: &schema.ObjectType{
+															AttributeTypes: []schema.ObjectAttributeType{
+																{
+																	Name:   "obj_obj_string_attr",
+																	String: &schema.StringType{},
+																},
+															},
 														},
 													},
 												},
@@ -297,6 +303,30 @@ func TestSpecification_JSONUnmarshal(t *testing.T) {
 									},
 								},
 								{
+									Name: "object_attribute_attribute_types_object_custom_type",
+									Object: &datasource.ObjectAttribute{
+										AttributeTypes: []schema.ObjectAttributeType{
+											{
+												Name: "obj_object_attr",
+												Object: &schema.ObjectType{
+													AttributeTypes: []schema.ObjectAttributeType{
+														{
+															Name:   "obj_object_string_attr",
+															String: &schema.StringType{},
+														},
+													},
+													CustomType: &schema.CustomType{
+														Import:    pointer("github.com/hashicorp/terraform-plugin-framework/types/basetypes"),
+														Type:      "basetypes.ObjectType",
+														ValueType: "basetypes.ObjectValue",
+													},
+												},
+											},
+										},
+										ComputedOptionalRequired: schema.Computed,
+									},
+								},
+								{
 									Name: "object_attribute_attribute_types_string_custom_type",
 									Object: &datasource.ObjectAttribute{
 										AttributeTypes: []schema.ObjectAttributeType{
@@ -355,10 +385,12 @@ func TestSpecification_JSONUnmarshal(t *testing.T) {
 												Name: "obj_list_attr",
 												List: &schema.ListType{
 													ElementType: schema.ElementType{
-														Object: []schema.ObjectAttributeType{
-															{
-																Name:   "obj_list_obj_attr",
-																String: &schema.StringType{},
+														Object: &schema.ObjectType{
+															AttributeTypes: []schema.ObjectAttributeType{
+																{
+																	Name:   "obj_list_obj_attr",
+																	String: &schema.StringType{},
+																},
 															},
 														},
 													},
@@ -859,10 +891,12 @@ func TestSpecification_JSONUnmarshal(t *testing.T) {
 								List: &provider.ListAttribute{
 									OptionalRequired: schema.Optional,
 									ElementType: schema.ElementType{
-										Object: []schema.ObjectAttributeType{
-											{
-												Name:   "obj_string_attr",
-												String: &schema.StringType{},
+										Object: &schema.ObjectType{
+											AttributeTypes: []schema.ObjectAttributeType{
+												{
+													Name:   "obj_string_attr",
+													String: &schema.StringType{},
+												},
 											},
 										},
 									},
@@ -873,13 +907,17 @@ func TestSpecification_JSONUnmarshal(t *testing.T) {
 								List: &provider.ListAttribute{
 									OptionalRequired: schema.Optional,
 									ElementType: schema.ElementType{
-										Object: []schema.ObjectAttributeType{
-											{
-												Name: "obj_obj_attr",
-												Object: []schema.ObjectAttributeType{
-													{
-														Name:   "obj_obj_string_attr",
-														String: &schema.StringType{},
+										Object: &schema.ObjectType{
+											AttributeTypes: []schema.ObjectAttributeType{
+												{
+													Name: "obj_obj_attr",
+													Object: &schema.ObjectType{
+														AttributeTypes: []schema.ObjectAttributeType{
+															{
+																Name:   "obj_obj_string_attr",
+																String: &schema.StringType{},
+															},
+														},
 													},
 												},
 											},
@@ -971,6 +1009,30 @@ func TestSpecification_JSONUnmarshal(t *testing.T) {
 								},
 							},
 							{
+								Name: "object_attribute_attribute_types_object_custom_type",
+								Object: &provider.ObjectAttribute{
+									AttributeTypes: []schema.ObjectAttributeType{
+										{
+											Name: "obj_object_attr",
+											Object: &schema.ObjectType{
+												AttributeTypes: []schema.ObjectAttributeType{
+													{
+														Name:   "obj_object_string_attr",
+														String: &schema.StringType{},
+													},
+												},
+												CustomType: &schema.CustomType{
+													Import:    pointer("github.com/hashicorp/terraform-plugin-framework/types/basetypes"),
+													Type:      "basetypes.ObjectType",
+													ValueType: "basetypes.ObjectValue",
+												},
+											},
+										},
+									},
+									OptionalRequired: schema.Optional,
+								},
+							},
+							{
 								Name: "object_attribute_attribute_types_string_custom_type",
 								Object: &provider.ObjectAttribute{
 									AttributeTypes: []schema.ObjectAttributeType{
@@ -1029,10 +1091,12 @@ func TestSpecification_JSONUnmarshal(t *testing.T) {
 											Name: "obj_list_attr",
 											List: &schema.ListType{
 												ElementType: schema.ElementType{
-													Object: []schema.ObjectAttributeType{
-														{
-															Name:   "obj_list_obj_attr",
-															String: &schema.StringType{},
+													Object: &schema.ObjectType{
+														AttributeTypes: []schema.ObjectAttributeType{
+															{
+																Name:   "obj_list_obj_attr",
+																String: &schema.StringType{},
+															},
 														},
 													},
 												},
@@ -1592,10 +1656,12 @@ func TestSpecification_JSONUnmarshal(t *testing.T) {
 									List: &resource.ListAttribute{
 										ComputedOptionalRequired: schema.Computed,
 										ElementType: schema.ElementType{
-											Object: []schema.ObjectAttributeType{
-												{
-													Name:   "obj_string_attr",
-													String: &schema.StringType{},
+											Object: &schema.ObjectType{
+												AttributeTypes: []schema.ObjectAttributeType{
+													{
+														Name:   "obj_string_attr",
+														String: &schema.StringType{},
+													},
 												},
 											},
 										},
@@ -1606,13 +1672,17 @@ func TestSpecification_JSONUnmarshal(t *testing.T) {
 									List: &resource.ListAttribute{
 										ComputedOptionalRequired: schema.Computed,
 										ElementType: schema.ElementType{
-											Object: []schema.ObjectAttributeType{
-												{
-													Name: "obj_obj_attr",
-													Object: []schema.ObjectAttributeType{
-														{
-															Name:   "obj_obj_string_attr",
-															String: &schema.StringType{},
+											Object: &schema.ObjectType{
+												AttributeTypes: []schema.ObjectAttributeType{
+													{
+														Name: "obj_obj_attr",
+														Object: &schema.ObjectType{
+															AttributeTypes: []schema.ObjectAttributeType{
+																{
+																	Name:   "obj_obj_string_attr",
+																	String: &schema.StringType{},
+																},
+															},
 														},
 													},
 												},
@@ -1716,6 +1786,30 @@ func TestSpecification_JSONUnmarshal(t *testing.T) {
 									},
 								},
 								{
+									Name: "object_attribute_attribute_types_object_custom_type",
+									Object: &resource.ObjectAttribute{
+										AttributeTypes: []schema.ObjectAttributeType{
+											{
+												Name: "obj_object_attr",
+												Object: &schema.ObjectType{
+													AttributeTypes: []schema.ObjectAttributeType{
+														{
+															Name:   "obj_object_string_attr",
+															String: &schema.StringType{},
+														},
+													},
+													CustomType: &schema.CustomType{
+														Import:    pointer("github.com/hashicorp/terraform-plugin-framework/types/basetypes"),
+														Type:      "basetypes.ObjectType",
+														ValueType: "basetypes.ObjectValue",
+													},
+												},
+											},
+										},
+										ComputedOptionalRequired: schema.Computed,
+									},
+								},
+								{
 									Name: "object_attribute_attribute_types_string_custom_type",
 									Object: &resource.ObjectAttribute{
 										AttributeTypes: []schema.ObjectAttributeType{
@@ -1774,10 +1868,12 @@ func TestSpecification_JSONUnmarshal(t *testing.T) {
 												Name: "obj_list_attr",
 												List: &schema.ListType{
 													ElementType: schema.ElementType{
-														Object: []schema.ObjectAttributeType{
-															{
-																Name:   "obj_list_obj_attr",
-																String: &schema.StringType{},
+														Object: &schema.ObjectType{
+															AttributeTypes: []schema.ObjectAttributeType{
+																{
+																	Name:   "obj_list_obj_attr",
+																	String: &schema.StringType{},
+																},
 															},
 														},
 													},
@@ -2957,12 +3053,14 @@ func TestSpecification_Validate_DataSources(t *testing.T) {
 										AttributeTypes: []schema.ObjectAttributeType{
 											{
 												Name: "obj_attr",
-												Object: []schema.ObjectAttributeType{
-													{
-														Name: "obj_obj_attr",
-													},
-													{
-														Name: "obj_obj_attr",
+												Object: &schema.ObjectType{
+													AttributeTypes: []schema.ObjectAttributeType{
+														{
+															Name: "obj_obj_attr",
+														},
+														{
+															Name: "obj_obj_attr",
+														},
 													},
 												},
 											},
@@ -2989,9 +3087,11 @@ func TestSpecification_Validate_DataSources(t *testing.T) {
 										AttributeTypes: []schema.ObjectAttributeType{
 											{
 												Name: "obj_attr",
-												Object: []schema.ObjectAttributeType{
-													{
-														Name: "obj_attr",
+												Object: &schema.ObjectType{
+													AttributeTypes: []schema.ObjectAttributeType{
+														{
+															Name: "obj_attr",
+														},
 													},
 												},
 											},
@@ -3682,12 +3782,14 @@ func TestSpecification_Validate_Provider(t *testing.T) {
 									AttributeTypes: []schema.ObjectAttributeType{
 										{
 											Name: "obj_attr",
-											Object: []schema.ObjectAttributeType{
-												{
-													Name: "obj_obj_attr",
-												},
-												{
-													Name: "obj_obj_attr",
+											Object: &schema.ObjectType{
+												AttributeTypes: []schema.ObjectAttributeType{
+													{
+														Name: "obj_obj_attr",
+													},
+													{
+														Name: "obj_obj_attr",
+													},
 												},
 											},
 										},
@@ -3712,9 +3814,11 @@ func TestSpecification_Validate_Provider(t *testing.T) {
 									AttributeTypes: []schema.ObjectAttributeType{
 										{
 											Name: "obj_attr",
-											Object: []schema.ObjectAttributeType{
-												{
-													Name: "obj_attr",
+											Object: &schema.ObjectType{
+												AttributeTypes: []schema.ObjectAttributeType{
+													{
+														Name: "obj_attr",
+													},
 												},
 											},
 										},
@@ -4484,12 +4588,14 @@ func TestSpecification_Validate_Resources(t *testing.T) {
 										AttributeTypes: []schema.ObjectAttributeType{
 											{
 												Name: "obj_attr",
-												Object: []schema.ObjectAttributeType{
-													{
-														Name: "obj_obj_attr",
-													},
-													{
-														Name: "obj_obj_attr",
+												Object: &schema.ObjectType{
+													AttributeTypes: []schema.ObjectAttributeType{
+														{
+															Name: "obj_obj_attr",
+														},
+														{
+															Name: "obj_obj_attr",
+														},
 													},
 												},
 											},
@@ -4516,9 +4622,11 @@ func TestSpecification_Validate_Resources(t *testing.T) {
 										AttributeTypes: []schema.ObjectAttributeType{
 											{
 												Name: "obj_attr",
-												Object: []schema.ObjectAttributeType{
-													{
-														Name: "obj_attr",
+												Object: &schema.ObjectType{
+													AttributeTypes: []schema.ObjectAttributeType{
+														{
+															Name: "obj_attr",
+														},
 													},
 												},
 											},
@@ -4681,10 +4789,12 @@ func TestSpecification_Generate(t *testing.T) {
 									List: &datasource.ListAttribute{
 										ComputedOptionalRequired: schema.Computed,
 										ElementType: schema.ElementType{
-											Object: []schema.ObjectAttributeType{
-												{
-													Name:   "obj_string_attr",
-													String: &schema.StringType{},
+											Object: &schema.ObjectType{
+												AttributeTypes: []schema.ObjectAttributeType{
+													{
+														Name:   "obj_string_attr",
+														String: &schema.StringType{},
+													},
 												},
 											},
 										},
@@ -4695,13 +4805,17 @@ func TestSpecification_Generate(t *testing.T) {
 									List: &datasource.ListAttribute{
 										ComputedOptionalRequired: schema.Computed,
 										ElementType: schema.ElementType{
-											Object: []schema.ObjectAttributeType{
-												{
-													Name: "obj_obj_attr",
-													Object: []schema.ObjectAttributeType{
-														{
-															Name:   "obj_obj_string_attr",
-															String: &schema.StringType{},
+											Object: &schema.ObjectType{
+												AttributeTypes: []schema.ObjectAttributeType{
+													{
+														Name: "obj_obj_attr",
+														Object: &schema.ObjectType{
+															AttributeTypes: []schema.ObjectAttributeType{
+																{
+																	Name:   "obj_obj_string_attr",
+																	String: &schema.StringType{},
+																},
+															},
 														},
 													},
 												},
@@ -4793,6 +4907,30 @@ func TestSpecification_Generate(t *testing.T) {
 									},
 								},
 								{
+									Name: "object_attribute_attribute_types_object_custom_type",
+									Object: &datasource.ObjectAttribute{
+										AttributeTypes: []schema.ObjectAttributeType{
+											{
+												Name: "obj_object_attr",
+												Object: &schema.ObjectType{
+													AttributeTypes: []schema.ObjectAttributeType{
+														{
+															Name:   "obj_object_string_attr",
+															String: &schema.StringType{},
+														},
+													},
+													CustomType: &schema.CustomType{
+														Import:    pointer("github.com/hashicorp/terraform-plugin-framework/types/basetypes"),
+														Type:      "basetypes.ObjectType",
+														ValueType: "basetypes.ObjectValue",
+													},
+												},
+											},
+										},
+										ComputedOptionalRequired: schema.Computed,
+									},
+								},
+								{
 									Name: "object_attribute_attribute_types_string_custom_type",
 									Object: &datasource.ObjectAttribute{
 										AttributeTypes: []schema.ObjectAttributeType{
@@ -4851,10 +4989,12 @@ func TestSpecification_Generate(t *testing.T) {
 												Name: "obj_list_attr",
 												List: &schema.ListType{
 													ElementType: schema.ElementType{
-														Object: []schema.ObjectAttributeType{
-															{
-																Name:   "obj_list_obj_attr",
-																String: &schema.StringType{},
+														Object: &schema.ObjectType{
+															AttributeTypes: []schema.ObjectAttributeType{
+																{
+																	Name:   "obj_list_obj_attr",
+																	String: &schema.StringType{},
+																},
 															},
 														},
 													},
@@ -5355,10 +5495,12 @@ func TestSpecification_Generate(t *testing.T) {
 								List: &provider.ListAttribute{
 									OptionalRequired: schema.Optional,
 									ElementType: schema.ElementType{
-										Object: []schema.ObjectAttributeType{
-											{
-												Name:   "obj_string_attr",
-												String: &schema.StringType{},
+										Object: &schema.ObjectType{
+											AttributeTypes: []schema.ObjectAttributeType{
+												{
+													Name:   "obj_string_attr",
+													String: &schema.StringType{},
+												},
 											},
 										},
 									},
@@ -5369,13 +5511,17 @@ func TestSpecification_Generate(t *testing.T) {
 								List: &provider.ListAttribute{
 									OptionalRequired: schema.Optional,
 									ElementType: schema.ElementType{
-										Object: []schema.ObjectAttributeType{
-											{
-												Name: "obj_obj_attr",
-												Object: []schema.ObjectAttributeType{
-													{
-														Name:   "obj_obj_string_attr",
-														String: &schema.StringType{},
+										Object: &schema.ObjectType{
+											AttributeTypes: []schema.ObjectAttributeType{
+												{
+													Name: "obj_obj_attr",
+													Object: &schema.ObjectType{
+														AttributeTypes: []schema.ObjectAttributeType{
+															{
+																Name:   "obj_obj_string_attr",
+																String: &schema.StringType{},
+															},
+														},
 													},
 												},
 											},
@@ -5467,6 +5613,30 @@ func TestSpecification_Generate(t *testing.T) {
 								},
 							},
 							{
+								Name: "object_attribute_attribute_types_object_custom_type",
+								Object: &provider.ObjectAttribute{
+									AttributeTypes: []schema.ObjectAttributeType{
+										{
+											Name: "obj_object_attr",
+											Object: &schema.ObjectType{
+												AttributeTypes: []schema.ObjectAttributeType{
+													{
+														Name:   "obj_object_string_attr",
+														String: &schema.StringType{},
+													},
+												},
+												CustomType: &schema.CustomType{
+													Import:    pointer("github.com/hashicorp/terraform-plugin-framework/types/basetypes"),
+													Type:      "basetypes.ObjectType",
+													ValueType: "basetypes.ObjectValue",
+												},
+											},
+										},
+									},
+									OptionalRequired: schema.Optional,
+								},
+							},
+							{
 								Name: "object_attribute_attribute_types_string_custom_type",
 								Object: &provider.ObjectAttribute{
 									AttributeTypes: []schema.ObjectAttributeType{
@@ -5525,10 +5695,12 @@ func TestSpecification_Generate(t *testing.T) {
 											Name: "obj_list_attr",
 											List: &schema.ListType{
 												ElementType: schema.ElementType{
-													Object: []schema.ObjectAttributeType{
-														{
-															Name:   "obj_list_obj_attr",
-															String: &schema.StringType{},
+													Object: &schema.ObjectType{
+														AttributeTypes: []schema.ObjectAttributeType{
+															{
+																Name:   "obj_list_obj_attr",
+																String: &schema.StringType{},
+															},
 														},
 													},
 												},
@@ -6088,10 +6260,12 @@ func TestSpecification_Generate(t *testing.T) {
 									List: &resource.ListAttribute{
 										ComputedOptionalRequired: schema.Computed,
 										ElementType: schema.ElementType{
-											Object: []schema.ObjectAttributeType{
-												{
-													Name:   "obj_string_attr",
-													String: &schema.StringType{},
+											Object: &schema.ObjectType{
+												AttributeTypes: []schema.ObjectAttributeType{
+													{
+														Name:   "obj_string_attr",
+														String: &schema.StringType{},
+													},
 												},
 											},
 										},
@@ -6102,13 +6276,17 @@ func TestSpecification_Generate(t *testing.T) {
 									List: &resource.ListAttribute{
 										ComputedOptionalRequired: schema.Computed,
 										ElementType: schema.ElementType{
-											Object: []schema.ObjectAttributeType{
-												{
-													Name: "obj_obj_attr",
-													Object: []schema.ObjectAttributeType{
-														{
-															Name:   "obj_obj_string_attr",
-															String: &schema.StringType{},
+											Object: &schema.ObjectType{
+												AttributeTypes: []schema.ObjectAttributeType{
+													{
+														Name: "obj_obj_attr",
+														Object: &schema.ObjectType{
+															AttributeTypes: []schema.ObjectAttributeType{
+																{
+																	Name:   "obj_obj_string_attr",
+																	String: &schema.StringType{},
+																},
+															},
 														},
 													},
 												},
@@ -6212,6 +6390,30 @@ func TestSpecification_Generate(t *testing.T) {
 									},
 								},
 								{
+									Name: "object_attribute_attribute_types_object_custom_type",
+									Object: &resource.ObjectAttribute{
+										AttributeTypes: []schema.ObjectAttributeType{
+											{
+												Name: "obj_object_attr",
+												Object: &schema.ObjectType{
+													AttributeTypes: []schema.ObjectAttributeType{
+														{
+															Name:   "obj_object_string_attr",
+															String: &schema.StringType{},
+														},
+													},
+													CustomType: &schema.CustomType{
+														Import:    pointer("github.com/hashicorp/terraform-plugin-framework/types/basetypes"),
+														Type:      "basetypes.ObjectType",
+														ValueType: "basetypes.ObjectValue",
+													},
+												},
+											},
+										},
+										ComputedOptionalRequired: schema.Computed,
+									},
+								},
+								{
 									Name: "object_attribute_attribute_types_string_custom_type",
 									Object: &resource.ObjectAttribute{
 										AttributeTypes: []schema.ObjectAttributeType{
@@ -6270,10 +6472,12 @@ func TestSpecification_Generate(t *testing.T) {
 												Name: "obj_list_attr",
 												List: &schema.ListType{
 													ElementType: schema.ElementType{
-														Object: []schema.ObjectAttributeType{
-															{
-																Name:   "obj_list_obj_attr",
-																String: &schema.StringType{},
+														Object: &schema.ObjectType{
+															AttributeTypes: []schema.ObjectAttributeType{
+																{
+																	Name:   "obj_list_obj_attr",
+																	String: &schema.StringType{},
+																},
 															},
 														},
 													},


### PR DESCRIPTION
Closes #25

This breaking change ensures there is consistency that specification implementations can use `CustomType` with all types, in this case object types underlying any attribute type.

For existing implementations, such as:

```json
{
            "name": "list_object_attribute",
            "list": {
              "computed_optional_required": "computed",
              "element_type": {
                "object": [
                  {
                    "name": "obj_string_attr",
                    "string": {}
                  }
                ]
              }
            }
          },
```

Are now defined as:

```json
{
            "name": "list_object_attribute",
            "list": {
              "computed_optional_required": "computed",
              "element_type": {
                "object": {
                  "attribute_types": [
                    {
                      "name": "obj_string_attr",
                      "string": {}
                    }
                  ]
                }
              }
            }
          },
```

Note that there is now a slight inconsistency between how `CustomType` is defined on collection types (`ListType`, `MapType`, and `SetType`) that are already element types and need to include their own element type. The `CustomType` is specified along side the element type, rather than explicitly having an `ElementType` delineation.

Currently:

```json
          {
            "name": "map_list_string_attribute",
            "map": {
              "computed_optional_required": "computed",
              "element_type": {
                "list": {
                  "custom_type": {
                    "import": "github.com/hashicorp/terraform-plugin-framework/types/basetypes",
                    "type": "basetypes.ListType",
                    "value_type": "basetypes.ListValue"
                  },
                  "string": {}
                }
              }
            }
          },
```

It may make sense to reintroduce what was originally designed in the specification with the verbose `ElementType` property for clarity.

```json
          {
            "name": "map_list_string_attribute",
            "map": {
              "computed_optional_required": "computed",
              "element_type": {
                "list": {
                  "custom_type": {
                    "import": "github.com/hashicorp/terraform-plugin-framework/types/basetypes",
                    "type": "basetypes.ListType",
                    "value_type": "basetypes.ListValue"
                  },
                  "element_type": {
                    "string": {}
                  }
                }
              }
            }
          },
```