### PR TITLE
spec: Add minimum length validations for custom_type object type and value_type properties

### DIFF
--- a/spec/schema.json
+++ b/spec/schema.json
@@ -324,9 +324,11 @@
               "type": "string"
             },
             "type": {
+              "minLength": 1,
               "type": "string"
             },
             "value_type": {
+              "minLength": 1,
               "type": "string"
             }
           },


### PR DESCRIPTION
Closes #22

When setting a `custom_type` object `type` property to `""`, it generates this validation error:

```
--- FAIL: TestValidate (0.00s)
    --- FAIL: TestValidate/example (0.01s)
        validate_test.go:45: expected no error, got: provider.schema.attributes.27.set.custom_type.type: String length must be greater than or equal to 1
```