### PR TITLE
spec: Nest ListType, MapType, and SetType ElementType as explicit object property

### DIFF
--- a/schema/list_type.go
+++ b/schema/list_type.go
@@ -4,7 +4,7 @@
 package schema
 
 type ListType struct {
-	ElementType
+	ElementType ElementType `json:"element_type"`
 
 	// CustomType is a customization of the ListType.
 	CustomType *CustomType `json:"custom_type,omitempty"`

--- a/schema/map_type.go
+++ b/schema/map_type.go
@@ -4,7 +4,7 @@
 package schema
 
 type MapType struct {
-	ElementType
+	ElementType ElementType `json:"element_type"`
 
 	// CustomType is a customization of the MapType.
 	CustomType *CustomType `json:"custom_type,omitempty"`

--- a/schema/set_type.go
+++ b/schema/set_type.go
@@ -4,7 +4,7 @@
 package schema
 
 type SetType struct {
-	ElementType
+	ElementType ElementType `json:"element_type"`
 
 	// CustomType is a customization of the SetType.
 	CustomType *CustomType `json:"custom_type,omitempty"`

--- a/spec/example.json
+++ b/spec/example.json
@@ -99,7 +99,9 @@
               "computed_optional_required": "computed",
               "element_type": {
                 "map": {
-                  "string": {}
+                  "element_type": {
+                    "string": {}
+                  }
                 }
               }
             }
@@ -293,7 +295,9 @@
                 {
                   "name": "obj_list_attr",
                   "list": {
-                    "string": {}
+                    "element_type": {
+                      "string": {}
+                    }
                   }
                 }
               ]
@@ -307,13 +311,15 @@
                 {
                   "name": "obj_list_attr",
                   "list": {
-                    "object": {
-                      "attribute_types": [
-                        {
-                          "name": "obj_list_obj_attr",
-                          "string": {}
-                        }
-                      ]
+                    "element_type": {
+                      "object": {
+                        "attribute_types": [
+                          {
+                            "name": "obj_list_obj_attr",
+                            "string": {}
+                          }
+                        ]
+                      }
                     }
                   }
                 }
@@ -799,7 +805,9 @@
             "optional_required": "optional",
             "element_type": {
               "map": {
-                "string": {}
+                "element_type": {
+                  "string": {}
+                }
               }
             }
           }
@@ -993,7 +1001,9 @@
               {
                 "name": "obj_list_attr",
                 "list": {
-                  "string": {}
+                  "element_type": {
+                    "string": {}
+                  }
                 }
               }
             ]
@@ -1007,13 +1017,15 @@
               {
                 "name": "obj_list_attr",
                 "list": {
-                  "object": {
-                    "attribute_types": [
-                      {
-                        "name": "obj_list_obj_attr",
-                        "string": {}
-                      }
-                    ]
+                  "element_type": {
+                    "object": {
+                      "attribute_types": [
+                        {
+                          "name": "obj_list_obj_attr",
+                          "string": {}
+                        }
+                      ]
+                    }
                   }
                 }
               }
@@ -1560,7 +1572,9 @@
               "computed_optional_required": "computed",
               "element_type": {
                 "map": {
-                  "string": {}
+                  "element_type": {
+                    "string": {}
+                  }
                 }
               }
             }
@@ -1766,7 +1780,9 @@
                 {
                   "name": "obj_list_attr",
                   "list": {
-                    "string": {}
+                    "element_type": {
+                      "string": {}
+                    }
                   }
                 }
               ]
@@ -1780,13 +1796,15 @@
                 {
                   "name": "obj_list_attr",
                   "list": {
-                    "object": {
-                      "attribute_types": [
-                        {
-                          "name": "obj_list_obj_attr",
-                          "string": {}
-                        }
-                      ]
+                    "element_type": {
+                      "object": {
+                        "attribute_types": [
+                          {
+                            "name": "obj_list_obj_attr",
+                            "string": {}
+                          }
+                        ]
+                      }
                     }
                   }
                 }

--- a/spec/schema.json
+++ b/spec/schema.json
@@ -448,166 +448,30 @@
           "type": "object",
           "additionalProperties": false,
           "properties": {
-            "bool": {
-              "$ref": "#/$defs/schema_bool_type"
-            },
             "custom_type": {
               "$ref": "#/$defs/schema_custom_type"
             },
-            "float64": {
-              "$ref": "#/$defs/schema_float64_type"
-            },
-            "int64": {
-              "$ref": "#/$defs/schema_int64_type"
-            },
-            "list": {
-              "$ref": "#/$defs/schema_list_type"
-            },
-            "map": {
-              "$ref": "#/$defs/schema_map_type"
-            },
-            "number": {
-              "$ref": "#/$defs/schema_number_type"
-            },
-            "object": {
-              "$ref": "#/$defs/schema_object_type"
-            },
-            "set": {
-              "$ref": "#/$defs/schema_set_type"
-            },
-            "string": {
-              "$ref": "#/$defs/schema_string_type"
+            "element_type": {
+              "$ref": "#/$defs/schema_element_type"
             }
           },
-          "oneOf": [
-            {
-              "required": [
-                "bool"
-              ]
-            },
-            {
-              "required": [
-                "float64"
-              ]
-            },
-            {
-              "required": [
-                "int64"
-              ]
-            },
-            {
-              "required": [
-                "list"
-              ]
-            },
-            {
-              "required": [
-                "map"
-              ]
-            },
-            {
-              "required": [
-                "number"
-              ]
-            },
-            {
-              "required": [
-                "object"
-              ]
-            },
-            {
-              "required": [
-                "set"
-              ]
-            },
-            {
-              "required": [
-                "string"
-              ]
-            }
+          "required": [
+            "element_type"
           ]
         },
         "schema_map_type": {
           "type": "object",
           "additionalProperties": false,
           "properties": {
-            "bool": {
-              "$ref": "#/$defs/schema_bool_type"
-            },
             "custom_type": {
               "$ref": "#/$defs/schema_custom_type"
             },
-            "float64": {
-              "$ref": "#/$defs/schema_float64_type"
-            },
-            "int64": {
-              "$ref": "#/$defs/schema_int64_type"
-            },
-            "list": {
-              "$ref": "#/$defs/schema_list_type"
-            },
-            "map": {
-              "$ref": "#/$defs/schema_map_type"
-            },
-            "number": {
-              "$ref": "#/$defs/schema_number_type"
-            },
-            "object": {
-              "$ref": "#/$defs/schema_object_type"
-            },
-            "set": {
-              "$ref": "#/$defs/schema_set_type"
-            },
-            "string": {
-              "$ref": "#/$defs/schema_string_type"
+            "element_type": {
+              "$ref": "#/$defs/schema_element_type"
             }
           },
-          "oneOf": [
-            {
-              "required": [
-                "bool"
-              ]
-            },
-            {
-              "required": [
-                "float64"
-              ]
-            },
-            {
-              "required": [
-                "int64"
-              ]
-            },
-            {
-              "required": [
-                "list"
-              ]
-            },
-            {
-              "required": [
-                "map"
-              ]
-            },
-            {
-              "required": [
-                "number"
-              ]
-            },
-            {
-              "required": [
-                "object"
-              ]
-            },
-            {
-              "required": [
-                "set"
-              ]
-            },
-            {
-              "required": [
-                "string"
-              ]
-            }
+          "required": [
+            "element_type"
           ]
         },
         "schema_number_type": {
@@ -734,83 +598,15 @@
           "type": "object",
           "additionalProperties": false,
           "properties": {
-            "bool": {
-              "$ref": "#/$defs/schema_bool_type"
-            },
             "custom_type": {
               "$ref": "#/$defs/schema_custom_type"
             },
-            "float64": {
-              "$ref": "#/$defs/schema_float64_type"
-            },
-            "int64": {
-              "$ref": "#/$defs/schema_int64_type"
-            },
-            "list": {
-              "$ref": "#/$defs/schema_list_type"
-            },
-            "map": {
-              "$ref": "#/$defs/schema_map_type"
-            },
-            "number": {
-              "$ref": "#/$defs/schema_number_type"
-            },
-            "object": {
-              "$ref": "#/$defs/schema_object_type"
-            },
-            "set": {
-              "$ref": "#/$defs/schema_set_type"
-            },
-            "string": {
-              "$ref": "#/$defs/schema_string_type"
+            "element_type": {
+              "$ref": "#/$defs/schema_element_type"
             }
           },
-          "oneOf": [
-            {
-              "required": [
-                "bool"
-              ]
-            },
-            {
-              "required": [
-                "float64"
-              ]
-            },
-            {
-              "required": [
-                "int64"
-              ]
-            },
-            {
-              "required": [
-                "list"
-              ]
-            },
-            {
-              "required": [
-                "map"
-              ]
-            },
-            {
-              "required": [
-                "number"
-              ]
-            },
-            {
-              "required": [
-                "object"
-              ]
-            },
-            {
-              "required": [
-                "set"
-              ]
-            },
-            {
-              "required": [
-                "string"
-              ]
-            }
+          "required": [
+            "element_type"
           ]
         },
         "schema_string_type": {


### PR DESCRIPTION
Reference: https://github.com/hashicorp/terraform-plugin-codegen-spec/pull/26

For consistency with collection attribute types which use an explicit `element_type` object property and object types which use an explicit `attribute_types` property. An additional benefit is that it further distinguishes where a `custom_type` may apply.

Previous implementations:

```json
{
            "name": "list_map_attribute",
            "list": {
              "computed_optional_required": "computed",
              "element_type": {
                "map": {
                  "string": {}
                }
              }
            }
          },
```

Are now defined as:

```json
          {
            "name": "list_map_attribute",
            "list": {
              "computed_optional_required": "computed",
              "element_type": {
                "map": {
                  "element_type": {
                    "string": {}
                  }
                }
              }
            }
          },
```

The Go bindings and any consuming code do not require changes since Go implicitly required the `ElementType` field definition, even when it was using type embedding.