### PR TITLE
spec: Use array of string for custom default, plan modifier, and validator imports

### DIFF
--- a/schema/custom_default.go
+++ b/schema/custom_default.go
@@ -4,10 +4,10 @@
 package schema
 
 type CustomDefault struct {
-	Import           *string `json:"import,omitempty"`
-	SchemaDefinition string  `json:"schema_definition"`
+	Imports          []string `json:"imports,omitempty"`
+	SchemaDefinition string   `json:"schema_definition"`
 }
 
 func (c CustomDefault) HasImport() bool {
-	return c.Import != nil && *c.Import != ""
+	return len(c.Imports) > 0
 }

--- a/schema/custom_default_test.go
+++ b/schema/custom_default_test.go
@@ -22,15 +22,34 @@ func TestCustomDefault_HasImport(t *testing.T) {
 			customType: schema.CustomDefault{},
 			expected:   false,
 		},
-		"import-empty-string": {
+		"import-empty": {
 			customType: schema.CustomDefault{
-				Import: pointer(""),
+				Imports: []string{}, // disallowed by spec, but still worth checking
 			},
 			expected: false,
 		},
+		"import-empty-string": {
+			customType: schema.CustomDefault{
+				Imports: []string{
+					"", // disallowed by spec, but still worth checking
+				},
+			},
+			expected: true,
+		},
 		"import-string": {
 			customType: schema.CustomDefault{
-				Import: pointer("github.com/owner/repo/pkg"),
+				Imports: []string{
+					"github.com/owner/repo/pkg",
+				},
+			},
+			expected: true,
+		},
+		"import-strings": {
+			customType: schema.CustomDefault{
+				Imports: []string{
+					"github.com/owner/repo/pkg1",
+					"github.com/owner/repo/pkg2",
+				},
 			},
 			expected: true,
 		},

--- a/schema/custom_plan_modifier.go
+++ b/schema/custom_plan_modifier.go
@@ -4,10 +4,10 @@
 package schema
 
 type CustomPlanModifier struct {
-	Import           *string `json:"import,omitempty"`
-	SchemaDefinition string  `json:"schema_definition"`
+	Imports          []string `json:"imports,omitempty"`
+	SchemaDefinition string   `json:"schema_definition"`
 }
 
 func (c CustomPlanModifier) HasImport() bool {
-	return c.Import != nil && *c.Import != ""
+	return len(c.Imports) > 0
 }

--- a/schema/custom_plan_modifier_test.go
+++ b/schema/custom_plan_modifier_test.go
@@ -22,15 +22,34 @@ func TestCustomPlanModifier_HasImport(t *testing.T) {
 			customType: schema.CustomPlanModifier{},
 			expected:   false,
 		},
-		"import-empty-string": {
+		"import-empty": {
 			customType: schema.CustomPlanModifier{
-				Import: pointer(""),
+				Imports: []string{}, // disallowed by spec, but still worth checking
 			},
 			expected: false,
 		},
+		"import-empty-string": {
+			customType: schema.CustomPlanModifier{
+				Imports: []string{
+					"", // disallowed by spec, but still worth checking
+				},
+			},
+			expected: true,
+		},
 		"import-string": {
 			customType: schema.CustomPlanModifier{
-				Import: pointer("github.com/owner/repo/pkg"),
+				Imports: []string{
+					"github.com/owner/repo/pkg",
+				},
+			},
+			expected: true,
+		},
+		"import-strings": {
+			customType: schema.CustomPlanModifier{
+				Imports: []string{
+					"github.com/owner/repo/pkg1",
+					"github.com/owner/repo/pkg2",
+				},
 			},
 			expected: true,
 		},

--- a/schema/custom_validator.go
+++ b/schema/custom_validator.go
@@ -4,10 +4,10 @@
 package schema
 
 type CustomValidator struct {
-	Import           *string `json:"import,omitempty"`
-	SchemaDefinition string  `json:"schema_definition"`
+	Imports          []string `json:"imports,omitempty"`
+	SchemaDefinition string   `json:"schema_definition"`
 }
 
 func (c CustomValidator) HasImport() bool {
-	return c.Import != nil && *c.Import != ""
+	return len(c.Imports) > 0
 }

--- a/schema/custom_validator_test.go
+++ b/schema/custom_validator_test.go
@@ -22,15 +22,34 @@ func TestCustomValidator_HasImport(t *testing.T) {
 			customType: schema.CustomValidator{},
 			expected:   false,
 		},
-		"import-empty-string": {
+		"import-empty": {
 			customType: schema.CustomValidator{
-				Import: pointer(""),
+				Imports: []string{}, // disallowed by spec, but still worth checking
 			},
 			expected: false,
 		},
+		"import-empty-string": {
+			customType: schema.CustomValidator{
+				Imports: []string{
+					"", // disallowed by spec, but still worth checking
+				},
+			},
+			expected: true,
+		},
 		"import-string": {
 			customType: schema.CustomValidator{
-				Import: pointer("github.com/owner/repo/pkg"),
+				Imports: []string{
+					"github.com/owner/repo/pkg",
+				},
+			},
+			expected: true,
+		},
+		"import-strings": {
+			customType: schema.CustomValidator{
+				Imports: []string{
+					"github.com/owner/repo/pkg1",
+					"github.com/owner/repo/pkg2",
+				},
 			},
 			expected: true,
 		},

--- a/spec/example.json
+++ b/spec/example.json
@@ -1426,7 +1426,7 @@
                 },
                 {
                   "custom": {
-                    "import": "github.com/my_account/my_project/boolplanmodifier",
+                    "imports": ["github.com/my_account/my_project/boolplanmodifier"],
                     "schema_definition": "myboolplanmodifier.Modify()"
                   }
                 }
@@ -1434,7 +1434,7 @@
               "validators": [
                 {
                   "custom": {
-                    "import": "github.com/my_account/my_project/myboolvalidator",
+                    "imports": ["github.com/my_account/my_project/myboolvalidator"],
                     "schema_definition": "myboolvalidator.Validate()"
                   }
                 }
@@ -1542,8 +1542,12 @@
               "computed_optional_required": "optional",
               "default": {
                 "custom": {
-                  "import":           "github.com/hashicorp/terraform-plugin-framework/types",
-                  "schema_definition": "types.ListValueMust(types.String, []attr.Value{types.StringValue(\"example\")})"
+                  "imports": [
+                    "github.com/hashicorp/terraform-plugin-framework/attr",
+                    "github.com/hashicorp/terraform-plugin-framework/resource/schema/listdefault",
+                    "github.com/hashicorp/terraform-plugin-framework/types"
+                  ],
+                  "schema_definition": "listdefault.StaticValue(types.ListValueMust(types.String, []attr.Value{types.StringValue(\"example\")}))"
                 }
               },
               "element_type": {
@@ -1695,8 +1699,11 @@
               "computed_optional_required": "optional",
               "default": {
                 "custom": {
-                  "import": "math/big",
-                  "schema_definition": "big.NewFloat(123.45)"
+                  "imports": [
+                    "math/big",
+                    "github.com/hashicorp/terraform-plugin-framework/resource/schema/numberdefault"
+                  ],
+                  "schema_definition": "numberdefault.StaticBigFloat(big.NewFloat(123.45))"
                 }
               }
             }
@@ -1911,8 +1918,12 @@
               "computed_optional_required": "optional",
               "default": {
                 "custom": {
-                  "import":           "github.com/hashicorp/terraform-plugin-framework/types",
-                  "schema_definition": "types.SetValueMust(types.String, []attr.Value{types.StringValue(\"example\")})"
+                  "imports": [
+                    "github.com/hashicorp/terraform-plugin-framework/attr",
+                    "github.com/hashicorp/terraform-plugin-framework/resource/schema/setdefault",
+                    "github.com/hashicorp/terraform-plugin-framework/types"
+                  ],
+                  "schema_definition": "setdefault.StaticValue(types.SetValueMust(types.String, []attr.Value{types.StringValue(\"example\")}))"
                 }
               },
               "element_type": {

--- a/spec/schema.json
+++ b/spec/schema.json
@@ -2885,8 +2885,13 @@
     "schema_custom_default": {
       "type": "object",
       "properties": {
-        "import": {
-          "type": "string"
+        "imports": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "minItems": 1
         },
         "schema_definition": {
           "type": "string"
@@ -2899,8 +2904,13 @@
     "schema_custom_plan_modifier": {
       "type": "object",
       "properties": {
-        "import": {
-          "type": "string"
+        "imports": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "minItems": 1
         },
         "schema_definition": {
           "type": "string"
@@ -2913,8 +2923,13 @@
     "schema_custom_validator": {
       "type": "object",
       "properties": {
-        "import": {
-          "type": "string"
+        "imports": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "minItems": 1
         },
         "schema_definition": {
           "type": "string"

--- a/spec/specification_test.go
+++ b/spec/specification_test.go
@@ -1498,7 +1498,7 @@ func TestSpecification_JSONUnmarshal(t *testing.T) {
 											{},
 											{
 												Custom: &schema.CustomPlanModifier{
-													Import:           pointer("github.com/my_account/my_project/boolplanmodifier"),
+													Imports:          []string{"github.com/my_account/my_project/boolplanmodifier"},
 													SchemaDefinition: "myboolplanmodifier.Modify()",
 												},
 											},
@@ -1506,7 +1506,7 @@ func TestSpecification_JSONUnmarshal(t *testing.T) {
 										Validators: []schema.BoolValidator{
 											{
 												Custom: &schema.CustomValidator{
-													Import:           pointer("github.com/my_account/my_project/myboolvalidator"),
+													Imports:          []string{"github.com/my_account/my_project/myboolvalidator"},
 													SchemaDefinition: "myboolvalidator.Validate()",
 												},
 											},
@@ -1614,8 +1614,12 @@ func TestSpecification_JSONUnmarshal(t *testing.T) {
 										ComputedOptionalRequired: schema.Optional,
 										Default: &schema.ListDefault{
 											Custom: &schema.CustomDefault{
-												Import:           pointer("github.com/hashicorp/terraform-plugin-framework/types"),
-												SchemaDefinition: "types.ListValueMust(types.String, []attr.Value{types.StringValue(\"example\")})",
+												Imports: []string{
+													"github.com/hashicorp/terraform-plugin-framework/attr",
+													"github.com/hashicorp/terraform-plugin-framework/resource/schema/listdefault",
+													"github.com/hashicorp/terraform-plugin-framework/types",
+												},
+												SchemaDefinition: "listdefault.StaticValue(types.ListValueMust(types.String, []attr.Value{types.StringValue(\"example\")}))",
 											},
 										},
 										ElementType: schema.ElementType{
@@ -1767,8 +1771,11 @@ func TestSpecification_JSONUnmarshal(t *testing.T) {
 										ComputedOptionalRequired: schema.Optional,
 										Default: &schema.NumberDefault{
 											Custom: &schema.CustomDefault{
-												Import:           pointer("math/big"),
-												SchemaDefinition: "big.NewFloat(123.45)",
+												Imports: []string{
+													"math/big",
+													"github.com/hashicorp/terraform-plugin-framework/resource/schema/numberdefault",
+												},
+												SchemaDefinition: "numberdefault.StaticBigFloat(big.NewFloat(123.45))",
 											},
 										},
 									},
@@ -1983,8 +1990,12 @@ func TestSpecification_JSONUnmarshal(t *testing.T) {
 										ComputedOptionalRequired: schema.Optional,
 										Default: &schema.SetDefault{
 											Custom: &schema.CustomDefault{
-												Import:           pointer("github.com/hashicorp/terraform-plugin-framework/types"),
-												SchemaDefinition: "types.SetValueMust(types.String, []attr.Value{types.StringValue(\"example\")})",
+												Imports: []string{
+													"github.com/hashicorp/terraform-plugin-framework/attr",
+													"github.com/hashicorp/terraform-plugin-framework/resource/schema/setdefault",
+													"github.com/hashicorp/terraform-plugin-framework/types",
+												},
+												SchemaDefinition: "setdefault.StaticValue(types.SetValueMust(types.String, []attr.Value{types.StringValue(\"example\")}))",
 											},
 										},
 										ElementType: schema.ElementType{
@@ -6102,7 +6113,7 @@ func TestSpecification_Generate(t *testing.T) {
 											{},
 											{
 												Custom: &schema.CustomPlanModifier{
-													Import:           pointer("github.com/my_account/my_project/boolplanmodifier"),
+													Imports:          []string{"github.com/my_account/my_project/boolplanmodifier"},
 													SchemaDefinition: "myboolplanmodifier.Modify()",
 												},
 											},
@@ -6110,7 +6121,7 @@ func TestSpecification_Generate(t *testing.T) {
 										Validators: []schema.BoolValidator{
 											{
 												Custom: &schema.CustomValidator{
-													Import:           pointer("github.com/my_account/my_project/myboolvalidator"),
+													Imports:          []string{"github.com/my_account/my_project/myboolvalidator"},
 													SchemaDefinition: "myboolvalidator.Validate()",
 												},
 											},
@@ -6218,8 +6229,12 @@ func TestSpecification_Generate(t *testing.T) {
 										ComputedOptionalRequired: schema.Optional,
 										Default: &schema.ListDefault{
 											Custom: &schema.CustomDefault{
-												Import:           pointer("github.com/hashicorp/terraform-plugin-framework/types"),
-												SchemaDefinition: "types.ListValueMust(types.String, []attr.Value{types.StringValue(\"example\")})",
+												Imports: []string{
+													"github.com/hashicorp/terraform-plugin-framework/attr",
+													"github.com/hashicorp/terraform-plugin-framework/resource/schema/listdefault",
+													"github.com/hashicorp/terraform-plugin-framework/types",
+												},
+												SchemaDefinition: "listdefault.StaticValue(types.ListValueMust(types.String, []attr.Value{types.StringValue(\"example\")}))",
 											},
 										},
 										ElementType: schema.ElementType{
@@ -6371,8 +6386,11 @@ func TestSpecification_Generate(t *testing.T) {
 										ComputedOptionalRequired: schema.Optional,
 										Default: &schema.NumberDefault{
 											Custom: &schema.CustomDefault{
-												Import:           pointer("math/big"),
-												SchemaDefinition: "big.NewFloat(123.45)",
+												Imports: []string{
+													"math/big",
+													"github.com/hashicorp/terraform-plugin-framework/resource/schema/numberdefault",
+												},
+												SchemaDefinition: "numberdefault.StaticBigFloat(big.NewFloat(123.45))",
 											},
 										},
 									},
@@ -6587,8 +6605,12 @@ func TestSpecification_Generate(t *testing.T) {
 										ComputedOptionalRequired: schema.Optional,
 										Default: &schema.SetDefault{
 											Custom: &schema.CustomDefault{
-												Import:           pointer("github.com/hashicorp/terraform-plugin-framework/types"),
-												SchemaDefinition: "types.SetValueMust(types.String, []attr.Value{types.StringValue(\"example\")})",
+												Imports: []string{
+													"github.com/hashicorp/terraform-plugin-framework/attr",
+													"github.com/hashicorp/terraform-plugin-framework/resource/schema/setdefault",
+													"github.com/hashicorp/terraform-plugin-framework/types",
+												},
+												SchemaDefinition: "setdefault.StaticValue(types.SetValueMust(types.String, []attr.Value{types.StringValue(\"example\")}))",
 											},
 										},
 										ElementType: schema.ElementType{


### PR DESCRIPTION
Closes #28

When dealing with custom schema functionality, such as defaults, plan modifiers, and validators, the schema definition of these may require multiple code imports to successfully compile. This change adjusts the import specification of these from a single string to an array of strings. This also includes additional validation in the specification on those imports, leaving the `imports` property still optional, but if defined, it must contain at least one item and each item must not be an empty string.

As an example, the following specification definition wasn't possible before, but now is:

```json
          {
            "name": "list_attribute_default_custom",
            "list": {
              "computed_optional_required": "optional_computed",
              "default": {
                "custom": {
                  "imports": [
                    "github.com/hashicorp/terraform-plugin-framework/attr",
                    "github.com/hashicorp/terraform-plugin-framework/resource/schema/listdefault",
                    "github.com/hashicorp/terraform-plugin-framework/types"
                  ],
                  "schema_definition": "listdefault.StaticValue(types.ListValueMust(types.String, []attr.Value{types.StringValue(\"example\")}))"
                }
              },
              "element_type": {
                "string": {}
              }
            }
          },
```