### PR TITLE
Remove framework-specific plan modifiers

### DIFF
--- a/spec/schema.json
+++ b/spec/schema.json
@@ -3460,32 +3460,10 @@
       "properties": {
         "custom": {
           "$ref": "#/$defs/schema_custom_plan_modifier"
-        },
-        "requires_replace": {
-          "type": "object",
-          "additionalProperties": false
-        },
-        "use_state_for_unknown": {
-          "type": "object",
-          "additionalProperties": false
         }
       },
-      "oneOf": [
-        {
-          "required": [
-            "custom"
-          ]
-        },
-        {
-          "required": [
-            "requires_replace"
-          ]
-        },
-        {
-          "required": [
-            "use_state_for_unknown"
-          ]
-        }
+      "required": [
+        "custom"
       ]
     },
     "schema_object_plan_modifiers": {


### PR DESCRIPTION
PR removes option to specify framework-specific plan modifiers.

These were not implemented in _codegen_framework_, and are too specific for inclusion in the spec in any case.