### PR TITLE
Adding ObjectAttributeTypes and ObjectAttributeType Equal() methods

### DIFF
--- a/schema/element_type_test.go
+++ b/schema/element_type_test.go
@@ -129,6 +129,15 @@ func TestElementType_Equal(t *testing.T) {
 			},
 			expected: false,
 		},
+		"match": {
+			elementType: schema.ElementType{
+				String: &schema.StringType{},
+			},
+			other: schema.ElementType{
+				String: &schema.StringType{},
+			},
+			expected: true,
+		},
 	}
 
 	for name, testCase := range testCases {

--- a/schema/object_attribute_type.go
+++ b/schema/object_attribute_type.go
@@ -7,27 +7,42 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 )
 
-type ObjectAttributeType struct {
-	Name string `json:"name"`
-
-	Bool    *BoolType    `json:"bool,omitempty"`
-	Float64 *Float64Type `json:"float64,omitempty"`
-	Int64   *Int64Type   `json:"int64,omitempty"`
-	List    *ListType    `json:"list,omitempty"`
-	Map     *MapType     `json:"map,omitempty"`
-	Number  *NumberType  `json:"number,omitempty"`
-	Object  *ObjectType  `json:"object,omitempty"`
-	Set     *SetType     `json:"set,omitempty"`
-	String  *StringType  `json:"string,omitempty"`
-}
-
-type ObjectValidateRequest struct {
-	Path string
-}
-
 type ObjectAttributeTypes []ObjectAttributeType
+
+func (o ObjectAttributeTypes) Equal(other ObjectAttributeTypes) bool {
+	if o == nil && other == nil {
+		return true
+	}
+
+	if o == nil || other == nil {
+		return false
+	}
+
+	if len(o) != len(other) {
+		return false
+	}
+
+	// Name is required by the spec JSON schema.
+	sort.Slice(o, func(i, j int) bool {
+		return o[i].Name < o[j].Name
+	})
+
+	// Name is required by the spec JSON schema.
+	sort.Slice(other, func(i, j int) bool {
+		return other[i].Name < other[j].Name
+	})
+
+	for k, objectAttributeType := range o {
+		if !objectAttributeType.Equal(other[k]) {
+			return false
+		}
+	}
+
+	return true
+}
 
 func (o ObjectAttributeTypes) Validate(ctx context.Context, req ObjectValidateRequest) error {
 	attrTypeNames := make(map[string]struct{}, len(o))
@@ -53,4 +68,150 @@ func (o ObjectAttributeTypes) Validate(ctx context.Context, req ObjectValidateRe
 	}
 
 	return errors.Join(errs, nestedErrs)
+}
+
+type ObjectAttributeType struct {
+	Name string `json:"name"`
+
+	Bool    *BoolType    `json:"bool,omitempty"`
+	Float64 *Float64Type `json:"float64,omitempty"`
+	Int64   *Int64Type   `json:"int64,omitempty"`
+	List    *ListType    `json:"list,omitempty"`
+	Map     *MapType     `json:"map,omitempty"`
+	Number  *NumberType  `json:"number,omitempty"`
+	Object  *ObjectType  `json:"object,omitempty"`
+	Set     *SetType     `json:"set,omitempty"`
+	String  *StringType  `json:"string,omitempty"`
+}
+
+func (o ObjectAttributeType) Equal(other ObjectAttributeType) bool {
+	if o.Name != other.Name {
+		return false
+	}
+
+	if o.Bool == nil && other.Bool != nil {
+		return false
+	}
+
+	if o.Bool != nil && other.Bool == nil {
+		return false
+	}
+
+	if o.Bool != nil && other.Bool != nil {
+		return o.Bool.CustomType.Equal(other.Bool.CustomType)
+	}
+
+	if o.Float64 == nil && other.Float64 != nil {
+		return false
+	}
+
+	if o.Float64 != nil && other.Float64 == nil {
+		return false
+	}
+
+	if o.Float64 != nil && other.Float64 != nil {
+		return o.Float64.CustomType.Equal(other.Float64.CustomType)
+	}
+
+	if o.Int64 == nil && other.Int64 != nil {
+		return false
+	}
+
+	if o.Int64 != nil && other.Int64 == nil {
+		return false
+	}
+
+	if o.Int64 != nil && other.Int64 != nil {
+		return o.Int64.CustomType.Equal(other.Int64.CustomType)
+	}
+
+	if o.List == nil && other.List != nil {
+		return false
+	}
+
+	if o.List != nil && other.List == nil {
+		return false
+	}
+
+	if o.List != nil && other.List != nil {
+		if !o.List.CustomType.Equal(other.List.CustomType) {
+			return false
+		}
+
+		return o.List.ElementType.Equal(other.List.ElementType)
+	}
+
+	if o.Map == nil && other.Map != nil {
+		return false
+	}
+
+	if o.Map != nil && other.Map == nil {
+		return false
+	}
+
+	if o.Map != nil && other.Map != nil {
+		if !o.Map.CustomType.Equal(other.Map.CustomType) {
+			return false
+		}
+
+		return o.Map.ElementType.Equal(other.Map.ElementType)
+	}
+
+	if o.Number == nil && other.Number != nil {
+		return false
+	}
+
+	if o.Number != nil && other.Number == nil {
+		return false
+	}
+
+	if o.Number != nil && other.Number != nil {
+		return o.Number.CustomType.Equal(other.Number.CustomType)
+	}
+
+	if o.Object == nil && other.Object != nil {
+		return false
+	}
+
+	if o.Object != nil && other.Object == nil {
+		return false
+	}
+
+	if o.Object != nil && other.Object != nil {
+		return o.Object.Equal(other.Object)
+	}
+
+	if o.Set == nil && other.Set != nil {
+		return false
+	}
+
+	if o.Set != nil && other.Set == nil {
+		return false
+	}
+
+	if o.Set != nil && other.Set != nil {
+		if !o.Set.CustomType.Equal(other.Set.CustomType) {
+			return false
+		}
+
+		return o.Set.ElementType.Equal(other.Set.ElementType)
+	}
+
+	if o.String == nil && other.String != nil {
+		return false
+	}
+
+	if o.String != nil && other.String == nil {
+		return false
+	}
+
+	if o.String != nil && other.String != nil {
+		return o.String.CustomType.Equal(other.String.CustomType)
+	}
+
+	return true
+}
+
+type ObjectValidateRequest struct {
+	Path string
 }

--- a/schema/object_attribute_type_test.go
+++ b/schema/object_attribute_type_test.go
@@ -1,0 +1,215 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package schema_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/hashicorp/terraform-plugin-codegen-spec/schema"
+)
+
+func TestObjectAttributeTypes_Equal(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		objectAttributeTypes schema.ObjectAttributeTypes
+		other                schema.ObjectAttributeTypes
+		expected             bool
+	}{
+		"object_attribute_types_both_nil": {
+			expected: true,
+		},
+		"object_attribute_types_nil_other_not_nil": {
+			other:    schema.ObjectAttributeTypes{},
+			expected: false,
+		},
+		"object_attribute_types_not_nil_other_nil": {
+			objectAttributeTypes: schema.ObjectAttributeTypes{},
+			expected:             false,
+		},
+		"object_attribute_types_len_diff": {
+			objectAttributeTypes: schema.ObjectAttributeTypes{
+				{},
+			},
+			other:    schema.ObjectAttributeTypes{},
+			expected: false,
+		},
+		"match": {
+			objectAttributeTypes: schema.ObjectAttributeTypes{},
+			other:                schema.ObjectAttributeTypes{},
+			expected:             true,
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.objectAttributeTypes.Equal(testCase.other)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}
+
+// TestObjectAttributeType_Equal does not test for equality of field type
+// CustomType as this is tested by TestCustomType_Equal.
+func TestObjectAttributeType_Equal(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		objectAttributeType schema.ObjectAttributeType
+		other               schema.ObjectAttributeType
+		expected            bool
+	}{
+		"name_mismatch": {
+			objectAttributeType: schema.ObjectAttributeType{
+				Name: "one",
+			},
+			other: schema.ObjectAttributeType{
+				Name: "two",
+			},
+			expected: false,
+		},
+		"bool_nil_other_not_nil": {
+			other: schema.ObjectAttributeType{
+				Bool: &schema.BoolType{},
+			},
+			expected: false,
+		},
+		"bool_not_nil_other_nil": {
+			objectAttributeType: schema.ObjectAttributeType{
+				Bool: &schema.BoolType{},
+			},
+			expected: false,
+		},
+		"float64_nil_other_not_nil": {
+			other: schema.ObjectAttributeType{
+				Float64: &schema.Float64Type{},
+			},
+			expected: false,
+		},
+		"float64_not_nil_other_nil": {
+			objectAttributeType: schema.ObjectAttributeType{
+				Float64: &schema.Float64Type{},
+			},
+			expected: false,
+		},
+		"int64_nil_other_not_nil": {
+			other: schema.ObjectAttributeType{
+				Int64: &schema.Int64Type{},
+			},
+			expected: false,
+		},
+		"int64_not_nil_other_nil": {
+			objectAttributeType: schema.ObjectAttributeType{
+				Int64: &schema.Int64Type{},
+			},
+			expected: false,
+		},
+		"list_nil_other_not_nil": {
+			other: schema.ObjectAttributeType{
+				List: &schema.ListType{},
+			},
+			expected: false,
+		},
+		"list_not_nil_other_nil": {
+			objectAttributeType: schema.ObjectAttributeType{
+				List: &schema.ListType{},
+			},
+			expected: false,
+		},
+		"map_nil_other_not_nil": {
+			other: schema.ObjectAttributeType{
+				Map: &schema.MapType{},
+			},
+			expected: false,
+		},
+		"map_not_nil_other_nil": {
+			objectAttributeType: schema.ObjectAttributeType{
+				Map: &schema.MapType{},
+			},
+			expected: false,
+		},
+		"number_nil_other_not_nil": {
+			other: schema.ObjectAttributeType{
+				Number: &schema.NumberType{},
+			},
+			expected: false,
+		},
+		"number_not_nil_other_nil": {
+			objectAttributeType: schema.ObjectAttributeType{
+				Number: &schema.NumberType{},
+			},
+			expected: false,
+		},
+		"object_nil_other_not_nil": {
+			other: schema.ObjectAttributeType{
+				Object: &schema.ObjectType{},
+			},
+			expected: false,
+		},
+		"object_not_nil_other_nil": {
+			objectAttributeType: schema.ObjectAttributeType{
+				Object: &schema.ObjectType{},
+			},
+			expected: false,
+		},
+		"set_nil_other_not_nil": {
+			other: schema.ObjectAttributeType{
+				Set: &schema.SetType{},
+			},
+			expected: false,
+		},
+		"set_not_nil_other_nil": {
+			objectAttributeType: schema.ObjectAttributeType{
+				Set: &schema.SetType{},
+			},
+			expected: false,
+		},
+		"string_nil_other_not_nil": {
+			other: schema.ObjectAttributeType{
+				String: &schema.StringType{},
+			},
+			expected: false,
+		},
+		"string_not_nil_other_nil": {
+			objectAttributeType: schema.ObjectAttributeType{
+				String: &schema.StringType{},
+			},
+			expected: false,
+		},
+		"match": {
+			objectAttributeType: schema.ObjectAttributeType{
+				Name: "one",
+				Bool: &schema.BoolType{},
+			},
+			other: schema.ObjectAttributeType{
+				Name: "one",
+				Bool: &schema.BoolType{},
+			},
+			expected: true,
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.objectAttributeType.Equal(testCase.other)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}

--- a/schema/object_type.go
+++ b/schema/object_type.go
@@ -19,51 +19,9 @@ func (o *ObjectType) Equal(other *ObjectType) bool {
 		return false
 	}
 
-	if !o.CustomType.Equal(other.CustomType) {
+	if !o.AttributeTypes.Equal(other.AttributeTypes) {
 		return false
 	}
 
-	if o.AttributeTypes == nil && other.AttributeTypes != nil {
-		return false
-	}
-
-	if o.AttributeTypes != nil && other.AttributeTypes == nil {
-		return false
-	}
-
-	for k, v := range o.AttributeTypes {
-		if v.Name != other.AttributeTypes[k].Name {
-			return false
-		}
-
-		a := ElementType{
-			Bool:    v.Bool,
-			Float64: v.Float64,
-			Int64:   v.Int64,
-			List:    v.List,
-			Map:     v.Map,
-			Number:  v.Number,
-			Object:  v.Object,
-			Set:     v.Set,
-			String:  v.String,
-		}
-
-		b := ElementType{
-			Bool:    other.AttributeTypes[k].Bool,
-			Float64: other.AttributeTypes[k].Float64,
-			Int64:   other.AttributeTypes[k].Int64,
-			List:    other.AttributeTypes[k].List,
-			Map:     other.AttributeTypes[k].Map,
-			Number:  other.AttributeTypes[k].Number,
-			Object:  other.AttributeTypes[k].Object,
-			Set:     other.AttributeTypes[k].Set,
-			String:  other.AttributeTypes[k].String,
-		}
-
-		if !a.Equal(b) {
-			return false
-		}
-	}
-
-	return true
+	return o.CustomType.Equal(other.CustomType)
 }


### PR DESCRIPTION
PR to add:

- `schema.ObjectAttributeTypes.Equal()` method
- `schema.ObjectAttributeType.Equal()` method

I believe this should be the final change required to move all of the equality logic into _codegen_spec_.