### PR TITLE
Add `CustomPlanModifiers` and `CustomValidators` functions to all `PlanModifiers` and `Validators` types

### DIFF
--- a/.changes/unreleased/ENHANCEMENTS-20240108-110509.yaml
+++ b/.changes/unreleased/ENHANCEMENTS-20240108-110509.yaml
@@ -1,0 +1,6 @@
+kind: ENHANCEMENTS
+body: Add `CustomPlanModifiers` type and `CustomPlanModifiers()` function to bool,
+  float64, int64, list, map, number, object, set, and string plan modifier types
+time: 2024-01-08T11:05:09.06701Z
+custom:
+  Issue: "77"

--- a/.changes/unreleased/ENHANCEMENTS-20240108-110625.yaml
+++ b/.changes/unreleased/ENHANCEMENTS-20240108-110625.yaml
@@ -1,0 +1,6 @@
+kind: ENHANCEMENTS
+body: Add `CustomValidators` type and `CustomValidators()` function to  bool, float64,
+  int64, list, map, number, object, set, and string validator types
+time: 2024-01-08T11:06:25.9511Z
+custom:
+  Issue: "77"

--- a/.changes/unreleased/ENHANCEMENTS-20240108-110802.yaml
+++ b/.changes/unreleased/ENHANCEMENTS-20240108-110802.yaml
@@ -1,0 +1,6 @@
+kind: ENHANCEMENTS
+body: Add `CustomDefault()` function to list, map, number, object, and set default
+  types
+time: 2024-01-08T11:08:02.113579Z
+custom:
+  Issue: "77"

--- a/schema/bool_plan_modifier.go
+++ b/schema/bool_plan_modifier.go
@@ -3,10 +3,25 @@
 
 package schema
 
-import "sort"
-
 // BoolPlanModifiers type defines BoolPlanModifier types
 type BoolPlanModifiers []BoolPlanModifier
+
+// CustomPlanModifiers returns CustomPlanModifier for each BoolPlanModifier.
+func (v BoolPlanModifiers) CustomPlanModifiers() CustomPlanModifiers {
+	var customPlanModifiers CustomPlanModifiers
+
+	for _, planModifier := range v {
+		customPlanModifier := planModifier.Custom
+
+		if customPlanModifier == nil {
+			continue
+		}
+
+		customPlanModifiers = append(customPlanModifiers, customPlanModifier)
+	}
+
+	return customPlanModifiers
+}
 
 // Equal returns true if the given BoolPlanModifiers is the same
 // length, and each of the BoolPlanModifier entries is equal.
@@ -23,38 +38,17 @@ func (v BoolPlanModifiers) Equal(other BoolPlanModifiers) bool {
 		return false
 	}
 
-	var planModifiers BoolPlanModifiers
+	planModifiers := v.CustomPlanModifiers()
 
-	var otherPlanModifiers BoolPlanModifiers
+	otherPlanModifiers := other.CustomPlanModifiers()
 
-	// Remove nils otherwise sort will panic.
-	for _, planModifier := range v {
-		if planModifier.Custom != nil {
-			planModifiers = append(planModifiers, planModifier)
-		}
-	}
-
-	// Remove nils otherwise sort will panic.
-	for _, planModifier := range other {
-		if planModifier.Custom != nil {
-			otherPlanModifiers = append(otherPlanModifiers, planModifier)
-		}
-	}
-
-	// Compare length after removing nils.
 	if len(planModifiers) != len(otherPlanModifiers) {
 		return false
 	}
 
-	// SchemaDefinition is required by the spec JSON schema.
-	sort.Slice(planModifiers, func(i, j int) bool {
-		return planModifiers[i].Custom.SchemaDefinition < planModifiers[j].Custom.SchemaDefinition
-	})
+	planModifiers.Sort()
 
-	// SchemaDefinition is required by the spec JSON schema.
-	sort.Slice(otherPlanModifiers, func(i, j int) bool {
-		return otherPlanModifiers[i].Custom.SchemaDefinition < otherPlanModifiers[j].Custom.SchemaDefinition
-	})
+	otherPlanModifiers.Sort()
 
 	for k, planModifier := range planModifiers {
 		if !planModifier.Equal(otherPlanModifiers[k]) {

--- a/schema/bool_validator.go
+++ b/schema/bool_validator.go
@@ -3,10 +3,25 @@
 
 package schema
 
-import "sort"
-
-// BoolValidators type defines BoolValidator types
+// BoolValidators type is a slice of BoolValidator.
 type BoolValidators []BoolValidator
+
+// CustomValidators returns CustomValidator for each BoolValidator.
+func (v BoolValidators) CustomValidators() CustomValidators {
+	var customValidators CustomValidators
+
+	for _, validator := range v {
+		customValidator := validator.Custom
+
+		if customValidator == nil {
+			continue
+		}
+
+		customValidators = append(customValidators, customValidator)
+	}
+
+	return customValidators
+}
 
 // Equal returns true if the given BoolValidators is the same
 // length, and each of the BoolValidator entries is equal.
@@ -23,38 +38,17 @@ func (v BoolValidators) Equal(other BoolValidators) bool {
 		return false
 	}
 
-	var validators BoolValidators
+	validators := v.CustomValidators()
 
-	var otherValidators BoolValidators
+	otherValidators := other.CustomValidators()
 
-	// Remove nils otherwise sort will panic.
-	for _, validator := range v {
-		if validator.Custom != nil {
-			validators = append(validators, validator)
-		}
-	}
-
-	// Remove nils otherwise sort will panic.
-	for _, validator := range other {
-		if validator.Custom != nil {
-			otherValidators = append(otherValidators, validator)
-		}
-	}
-
-	// Compare length after removing nils.
 	if len(validators) != len(otherValidators) {
 		return false
 	}
 
-	// SchemaDefinition is required by the spec JSON schema.
-	sort.Slice(validators, func(i, j int) bool {
-		return validators[i].Custom.SchemaDefinition < validators[j].Custom.SchemaDefinition
-	})
+	validators.Sort()
 
-	// SchemaDefinition is required by the spec JSON schema.
-	sort.Slice(otherValidators, func(i, j int) bool {
-		return otherValidators[i].Custom.SchemaDefinition < otherValidators[j].Custom.SchemaDefinition
-	})
+	otherValidators.Sort()
 
 	for k, validator := range validators {
 		if !validator.Equal(otherValidators[k]) {

--- a/schema/computed_optional_required.go
+++ b/schema/computed_optional_required.go
@@ -12,4 +12,8 @@ const (
 
 type ComputedOptionalRequired string
 
+func (c ComputedOptionalRequired) Equal(other ComputedOptionalRequired) bool {
+	return c == other
+}
+
 type OptionalRequired = ComputedOptionalRequired

--- a/schema/custom_plan_modifier.go
+++ b/schema/custom_plan_modifier.go
@@ -9,6 +9,26 @@ import (
 	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
 )
 
+// CustomPlanModifiers type is a slice of *CustomPlanModifier.
+type CustomPlanModifiers []*CustomPlanModifier
+
+// Sort will order on the basis of CustomPlanModifier.SchemaDefinition.
+func (c CustomPlanModifiers) Sort() {
+	// SchemaDefinition is required by the spec JSON schema.
+	sort.SliceStable(c, func(i, j int) bool {
+		switch {
+		case c[i] == nil && c[j] == nil:
+			return true
+		case c[i] == nil:
+			return false
+		case c[j] == nil:
+			return true
+		default:
+			return c[i].SchemaDefinition < c[j].SchemaDefinition
+		}
+	})
+}
+
 // CustomPlanModifier defines a custom type for a schema plan modifier.
 type CustomPlanModifier struct {
 	// Imports defines paths, and optional aliases for imported code.

--- a/schema/custom_plan_modifier_test.go
+++ b/schema/custom_plan_modifier_test.go
@@ -238,3 +238,58 @@ func TestCustomPlanModifier_Equal(t *testing.T) {
 		})
 	}
 }
+
+func TestCustomPlanModifiers_Sort(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		customPlanModifiers schema.CustomPlanModifiers
+		expected            schema.CustomPlanModifiers
+	}{
+		"custom-validators-nil": {
+			expected: nil,
+		},
+		"custom-validators-nil-entry": {
+			customPlanModifiers: schema.CustomPlanModifiers{nil},
+			expected:            schema.CustomPlanModifiers{nil},
+		},
+		"custom-validators-nil-entries": {
+			customPlanModifiers: schema.CustomPlanModifiers{nil, nil},
+			expected:            schema.CustomPlanModifiers{nil, nil},
+		},
+		"custom-validators-non-nil-with-nil-entry": {
+			customPlanModifiers: schema.CustomPlanModifiers{&schema.CustomPlanModifier{}, nil},
+			expected:            schema.CustomPlanModifiers{&schema.CustomPlanModifier{}, nil},
+		},
+		"custom-validators-nil-with-non-nil-entry": {
+			customPlanModifiers: schema.CustomPlanModifiers{nil, &schema.CustomPlanModifier{}},
+			expected:            schema.CustomPlanModifiers{&schema.CustomPlanModifier{}, nil},
+		},
+		"custom-validators-non-nil-entries-sorted": {
+			customPlanModifiers: schema.CustomPlanModifiers{&schema.CustomPlanModifier{SchemaDefinition: "x"}, &schema.CustomPlanModifier{SchemaDefinition: "y"}},
+			expected:            schema.CustomPlanModifiers{&schema.CustomPlanModifier{SchemaDefinition: "x"}, &schema.CustomPlanModifier{SchemaDefinition: "y"}},
+		},
+		"custom-validators-non-nil-entries-unsorted": {
+			customPlanModifiers: schema.CustomPlanModifiers{&schema.CustomPlanModifier{SchemaDefinition: "y"}, &schema.CustomPlanModifier{SchemaDefinition: "x"}},
+			expected:            schema.CustomPlanModifiers{&schema.CustomPlanModifier{SchemaDefinition: "x"}, &schema.CustomPlanModifier{SchemaDefinition: "y"}},
+		},
+		"custom-validators-multiple-entries": {
+			customPlanModifiers: schema.CustomPlanModifiers{nil, &schema.CustomPlanModifier{SchemaDefinition: "y"}, &schema.CustomPlanModifier{SchemaDefinition: "z"}, nil, &schema.CustomPlanModifier{SchemaDefinition: "x"}},
+			expected:            schema.CustomPlanModifiers{&schema.CustomPlanModifier{SchemaDefinition: "x"}, &schema.CustomPlanModifier{SchemaDefinition: "y"}, &schema.CustomPlanModifier{SchemaDefinition: "z"}, nil, nil},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			testCase.customPlanModifiers.Sort()
+
+			if diff := cmp.Diff(testCase.customPlanModifiers, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}

--- a/schema/custom_validator.go
+++ b/schema/custom_validator.go
@@ -9,6 +9,26 @@ import (
 	"github.com/hashicorp/terraform-plugin-codegen-spec/code"
 )
 
+// CustomValidators type is a slice of *CustomValidator.
+type CustomValidators []*CustomValidator
+
+// Sort will order on the basis of CustomValidator.SchemaDefinition.
+func (c CustomValidators) Sort() {
+	// SchemaDefinition is required by the spec JSON schema.
+	sort.SliceStable(c, func(i, j int) bool {
+		switch {
+		case c[i] == nil && c[j] == nil:
+			return true
+		case c[i] == nil:
+			return false
+		case c[j] == nil:
+			return true
+		default:
+			return c[i].SchemaDefinition < c[j].SchemaDefinition
+		}
+	})
+}
+
 // CustomValidator defines a custom type for a schema validator.
 type CustomValidator struct {
 	// Imports defines paths, and optional aliases for imported code.

--- a/schema/custom_validator_test.go
+++ b/schema/custom_validator_test.go
@@ -238,3 +238,58 @@ func TestCustomValidator_Equal(t *testing.T) {
 		})
 	}
 }
+
+func TestCustomValidators_Sort(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		customValidators schema.CustomValidators
+		expected         schema.CustomValidators
+	}{
+		"custom-validators-nil": {
+			expected: nil,
+		},
+		"custom-validators-nil-entry": {
+			customValidators: schema.CustomValidators{nil},
+			expected:         schema.CustomValidators{nil},
+		},
+		"custom-validators-nil-entries": {
+			customValidators: schema.CustomValidators{nil, nil},
+			expected:         schema.CustomValidators{nil, nil},
+		},
+		"custom-validators-non-nil-with-nil-entry": {
+			customValidators: schema.CustomValidators{&schema.CustomValidator{}, nil},
+			expected:         schema.CustomValidators{&schema.CustomValidator{}, nil},
+		},
+		"custom-validators-nil-with-non-nil-entry": {
+			customValidators: schema.CustomValidators{nil, &schema.CustomValidator{}},
+			expected:         schema.CustomValidators{&schema.CustomValidator{}, nil},
+		},
+		"custom-validators-non-nil-entries-sorted": {
+			customValidators: schema.CustomValidators{&schema.CustomValidator{SchemaDefinition: "x"}, &schema.CustomValidator{SchemaDefinition: "y"}},
+			expected:         schema.CustomValidators{&schema.CustomValidator{SchemaDefinition: "x"}, &schema.CustomValidator{SchemaDefinition: "y"}},
+		},
+		"custom-validators-non-nil-entries-unsorted": {
+			customValidators: schema.CustomValidators{&schema.CustomValidator{SchemaDefinition: "y"}, &schema.CustomValidator{SchemaDefinition: "x"}},
+			expected:         schema.CustomValidators{&schema.CustomValidator{SchemaDefinition: "x"}, &schema.CustomValidator{SchemaDefinition: "y"}},
+		},
+		"custom-validators-multiple-entries": {
+			customValidators: schema.CustomValidators{nil, &schema.CustomValidator{SchemaDefinition: "y"}, &schema.CustomValidator{SchemaDefinition: "z"}, nil, &schema.CustomValidator{SchemaDefinition: "x"}},
+			expected:         schema.CustomValidators{&schema.CustomValidator{SchemaDefinition: "x"}, &schema.CustomValidator{SchemaDefinition: "y"}, &schema.CustomValidator{SchemaDefinition: "z"}, nil, nil},
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			testCase.customValidators.Sort()
+
+			if diff := cmp.Diff(testCase.customValidators, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}

--- a/schema/float64_plan_modifier.go
+++ b/schema/float64_plan_modifier.go
@@ -3,10 +3,25 @@
 
 package schema
 
-import "sort"
-
 // Float64PlanModifiers type defines Float64PlanModifier types
 type Float64PlanModifiers []Float64PlanModifier
+
+// CustomPlanModifiers returns CustomPlanModifier for each Float64PlanModifier.
+func (v Float64PlanModifiers) CustomPlanModifiers() CustomPlanModifiers {
+	var customPlanModifiers CustomPlanModifiers
+
+	for _, planModifier := range v {
+		customPlanModifier := planModifier.Custom
+
+		if customPlanModifier == nil {
+			continue
+		}
+
+		customPlanModifiers = append(customPlanModifiers, customPlanModifier)
+	}
+
+	return customPlanModifiers
+}
 
 // Equal returns true if the given Float64PlanModifiers is the same
 // length, and each of the Float64PlanModifier entries is equal.
@@ -23,38 +38,17 @@ func (v Float64PlanModifiers) Equal(other Float64PlanModifiers) bool {
 		return false
 	}
 
-	var planModifiers Float64PlanModifiers
+	planModifiers := v.CustomPlanModifiers()
 
-	var otherPlanModifiers Float64PlanModifiers
+	otherPlanModifiers := other.CustomPlanModifiers()
 
-	// Remove nils otherwise sort will panic.
-	for _, planModifier := range v {
-		if planModifier.Custom != nil {
-			planModifiers = append(planModifiers, planModifier)
-		}
-	}
-
-	// Remove nils otherwise sort will panic.
-	for _, planModifier := range other {
-		if planModifier.Custom != nil {
-			otherPlanModifiers = append(otherPlanModifiers, planModifier)
-		}
-	}
-
-	// Compare length after removing nils.
 	if len(planModifiers) != len(otherPlanModifiers) {
 		return false
 	}
 
-	// SchemaDefinition is required by the spec JSON schema.
-	sort.Slice(planModifiers, func(i, j int) bool {
-		return planModifiers[i].Custom.SchemaDefinition < planModifiers[j].Custom.SchemaDefinition
-	})
+	planModifiers.Sort()
 
-	// SchemaDefinition is required by the spec JSON schema.
-	sort.Slice(otherPlanModifiers, func(i, j int) bool {
-		return otherPlanModifiers[i].Custom.SchemaDefinition < otherPlanModifiers[j].Custom.SchemaDefinition
-	})
+	otherPlanModifiers.Sort()
 
 	for k, planModifier := range planModifiers {
 		if !planModifier.Equal(otherPlanModifiers[k]) {
@@ -74,4 +68,5 @@ type Float64PlanModifier struct {
 // Equal returns true if the fields of the given Float64PlanModifier are equal.
 func (v Float64PlanModifier) Equal(other Float64PlanModifier) bool {
 	return v.Custom.Equal(other.Custom)
+
 }

--- a/schema/float64_validator.go
+++ b/schema/float64_validator.go
@@ -3,10 +3,25 @@
 
 package schema
 
-import "sort"
-
 // Float64Validators type defines Float64Validator types
 type Float64Validators []Float64Validator
+
+// CustomValidators returns CustomValidator for each Float64Validator.
+func (v Float64Validators) CustomValidators() CustomValidators {
+	var customValidators CustomValidators
+
+	for _, validator := range v {
+		customValidator := validator.Custom
+
+		if customValidator == nil {
+			continue
+		}
+
+		customValidators = append(customValidators, customValidator)
+	}
+
+	return customValidators
+}
 
 // Equal returns true if the given Float64Validators is the same
 // length, and each of the Float64Validator entries is equal.
@@ -23,38 +38,17 @@ func (v Float64Validators) Equal(other Float64Validators) bool {
 		return false
 	}
 
-	var validators Float64Validators
+	validators := v.CustomValidators()
 
-	var otherValidators Float64Validators
+	otherValidators := other.CustomValidators()
 
-	// Remove nils otherwise sort will panic.
-	for _, validator := range v {
-		if validator.Custom != nil {
-			validators = append(validators, validator)
-		}
-	}
-
-	// Remove nils otherwise sort will panic.
-	for _, validator := range other {
-		if validator.Custom != nil {
-			otherValidators = append(otherValidators, validator)
-		}
-	}
-
-	// Compare length after removing nils.
 	if len(validators) != len(otherValidators) {
 		return false
 	}
 
-	// SchemaDefinition is required by the spec JSON schema.
-	sort.Slice(validators, func(i, j int) bool {
-		return validators[i].Custom.SchemaDefinition < validators[j].Custom.SchemaDefinition
-	})
+	validators.Sort()
 
-	// SchemaDefinition is required by the spec JSON schema.
-	sort.Slice(otherValidators, func(i, j int) bool {
-		return otherValidators[i].Custom.SchemaDefinition < otherValidators[j].Custom.SchemaDefinition
-	})
+	otherValidators.Sort()
 
 	for k, validator := range validators {
 		if !validator.Equal(otherValidators[k]) {

--- a/schema/int64_plan_modifier.go
+++ b/schema/int64_plan_modifier.go
@@ -3,10 +3,25 @@
 
 package schema
 
-import "sort"
-
 // Int64PlanModifiers type defines Int64PlanModifier types
 type Int64PlanModifiers []Int64PlanModifier
+
+// CustomPlanModifiers returns CustomPlanModifier for each Int64PlanModifier.
+func (v Int64PlanModifiers) CustomPlanModifiers() CustomPlanModifiers {
+	var customPlanModifiers CustomPlanModifiers
+
+	for _, planModifier := range v {
+		customPlanModifier := planModifier.Custom
+
+		if customPlanModifier == nil {
+			continue
+		}
+
+		customPlanModifiers = append(customPlanModifiers, customPlanModifier)
+	}
+
+	return customPlanModifiers
+}
 
 // Equal returns true if the given Int64PlanModifiers is the same
 // length, and each of the Int64PlanModifier entries is equal.
@@ -23,38 +38,17 @@ func (v Int64PlanModifiers) Equal(other Int64PlanModifiers) bool {
 		return false
 	}
 
-	var planModifiers Int64PlanModifiers
+	planModifiers := v.CustomPlanModifiers()
 
-	var otherPlanModifiers Int64PlanModifiers
+	otherPlanModifiers := other.CustomPlanModifiers()
 
-	// Remove nils otherwise sort will panic.
-	for _, planModifier := range v {
-		if planModifier.Custom != nil {
-			planModifiers = append(planModifiers, planModifier)
-		}
-	}
-
-	// Remove nils otherwise sort will panic.
-	for _, planModifier := range other {
-		if planModifier.Custom != nil {
-			otherPlanModifiers = append(otherPlanModifiers, planModifier)
-		}
-	}
-
-	// Compare length after removing nils.
 	if len(planModifiers) != len(otherPlanModifiers) {
 		return false
 	}
 
-	// SchemaDefinition is required by the spec JSON schema.
-	sort.Slice(planModifiers, func(i, j int) bool {
-		return planModifiers[i].Custom.SchemaDefinition < planModifiers[j].Custom.SchemaDefinition
-	})
+	planModifiers.Sort()
 
-	// SchemaDefinition is required by the spec JSON schema.
-	sort.Slice(otherPlanModifiers, func(i, j int) bool {
-		return otherPlanModifiers[i].Custom.SchemaDefinition < otherPlanModifiers[j].Custom.SchemaDefinition
-	})
+	otherPlanModifiers.Sort()
 
 	for k, planModifier := range planModifiers {
 		if !planModifier.Equal(otherPlanModifiers[k]) {

--- a/schema/int64_validator.go
+++ b/schema/int64_validator.go
@@ -3,10 +3,25 @@
 
 package schema
 
-import "sort"
-
 // Int64Validators type defines Int64Validator types
 type Int64Validators []Int64Validator
+
+// CustomValidators returns CustomValidator for each Float64Validator.
+func (v Int64Validators) CustomValidators() CustomValidators {
+	var customValidators CustomValidators
+
+	for _, validator := range v {
+		customValidator := validator.Custom
+
+		if customValidator == nil {
+			continue
+		}
+
+		customValidators = append(customValidators, customValidator)
+	}
+
+	return customValidators
+}
 
 // Equal returns true if the given Int64Validators is the same
 // length, and each of the Int64Validator entries is equal.
@@ -23,38 +38,17 @@ func (v Int64Validators) Equal(other Int64Validators) bool {
 		return false
 	}
 
-	var validators Int64Validators
+	validators := v.CustomValidators()
 
-	var otherValidators Int64Validators
+	otherValidators := other.CustomValidators()
 
-	// Remove nils otherwise sort will panic.
-	for _, validator := range v {
-		if validator.Custom != nil {
-			validators = append(validators, validator)
-		}
-	}
-
-	// Remove nils otherwise sort will panic.
-	for _, validator := range other {
-		if validator.Custom != nil {
-			otherValidators = append(otherValidators, validator)
-		}
-	}
-
-	// Compare length after removing nils.
 	if len(validators) != len(otherValidators) {
 		return false
 	}
 
-	// SchemaDefinition is required by the spec JSON schema.
-	sort.Slice(validators, func(i, j int) bool {
-		return validators[i].Custom.SchemaDefinition < validators[j].Custom.SchemaDefinition
-	})
+	validators.Sort()
 
-	// SchemaDefinition is required by the spec JSON schema.
-	sort.Slice(otherValidators, func(i, j int) bool {
-		return otherValidators[i].Custom.SchemaDefinition < otherValidators[j].Custom.SchemaDefinition
-	})
+	otherValidators.Sort()
 
 	for k, validator := range validators {
 		if !validator.Equal(otherValidators[k]) {

--- a/schema/list_default.go
+++ b/schema/list_default.go
@@ -9,6 +9,15 @@ type ListDefault struct {
 	Custom *CustomDefault `json:"custom,omitempty"`
 }
 
+// CustomDefault returns *CustomDefault.
+func (d *ListDefault) CustomDefault() *CustomDefault {
+	if d == nil {
+		return nil
+	}
+
+	return d.Custom
+}
+
 // Equal returns true if all fields of the given ListDefault are equal.
 func (d *ListDefault) Equal(other *ListDefault) bool {
 	if d == nil && other == nil {

--- a/schema/list_plan_modifier.go
+++ b/schema/list_plan_modifier.go
@@ -3,10 +3,25 @@
 
 package schema
 
-import "sort"
-
 // ListPlanModifiers type defines ListPlanModifier types
 type ListPlanModifiers []ListPlanModifier
+
+// CustomPlanModifiers returns CustomPlanModifier for each ListPlanModifier.
+func (v ListPlanModifiers) CustomPlanModifiers() CustomPlanModifiers {
+	var customPlanModifiers CustomPlanModifiers
+
+	for _, planModifier := range v {
+		customPlanModifier := planModifier.Custom
+
+		if customPlanModifier == nil {
+			continue
+		}
+
+		customPlanModifiers = append(customPlanModifiers, customPlanModifier)
+	}
+
+	return customPlanModifiers
+}
 
 // Equal returns true if the given ListPlanModifiers is the same
 // length, and each of the ListPlanModifier entries is equal.
@@ -23,38 +38,17 @@ func (v ListPlanModifiers) Equal(other ListPlanModifiers) bool {
 		return false
 	}
 
-	var planModifiers ListPlanModifiers
+	planModifiers := v.CustomPlanModifiers()
 
-	var otherPlanModifiers ListPlanModifiers
+	otherPlanModifiers := other.CustomPlanModifiers()
 
-	// Remove nils otherwise sort will panic.
-	for _, planModifier := range v {
-		if planModifier.Custom != nil {
-			planModifiers = append(planModifiers, planModifier)
-		}
-	}
-
-	// Remove nils otherwise sort will panic.
-	for _, planModifier := range other {
-		if planModifier.Custom != nil {
-			otherPlanModifiers = append(otherPlanModifiers, planModifier)
-		}
-	}
-
-	// Compare length after removing nils.
 	if len(planModifiers) != len(otherPlanModifiers) {
 		return false
 	}
 
-	// SchemaDefinition is required by the spec JSON schema.
-	sort.Slice(planModifiers, func(i, j int) bool {
-		return planModifiers[i].Custom.SchemaDefinition < planModifiers[j].Custom.SchemaDefinition
-	})
+	planModifiers.Sort()
 
-	// SchemaDefinition is required by the spec JSON schema.
-	sort.Slice(otherPlanModifiers, func(i, j int) bool {
-		return otherPlanModifiers[i].Custom.SchemaDefinition < otherPlanModifiers[j].Custom.SchemaDefinition
-	})
+	otherPlanModifiers.Sort()
 
 	for k, planModifier := range planModifiers {
 		if !planModifier.Equal(otherPlanModifiers[k]) {

--- a/schema/map_default.go
+++ b/schema/map_default.go
@@ -9,6 +9,15 @@ type MapDefault struct {
 	Custom *CustomDefault `json:"custom,omitempty"`
 }
 
+// CustomDefault returns *CustomDefault.
+func (d *MapDefault) CustomDefault() *CustomDefault {
+	if d == nil {
+		return nil
+	}
+
+	return d.Custom
+}
+
 // Equal returns true if all fields of the given MapDefault are equal.
 func (d *MapDefault) Equal(other *MapDefault) bool {
 	if d == nil && other == nil {

--- a/schema/map_plan_modifier.go
+++ b/schema/map_plan_modifier.go
@@ -3,10 +3,25 @@
 
 package schema
 
-import "sort"
-
 // MapPlanModifiers type defines MapPlanModifier types
 type MapPlanModifiers []MapPlanModifier
+
+// CustomPlanModifiers returns CustomPlanModifier for each MapPlanModifier.
+func (v MapPlanModifiers) CustomPlanModifiers() CustomPlanModifiers {
+	var customPlanModifiers CustomPlanModifiers
+
+	for _, planModifier := range v {
+		customPlanModifier := planModifier.Custom
+
+		if customPlanModifier == nil {
+			continue
+		}
+
+		customPlanModifiers = append(customPlanModifiers, customPlanModifier)
+	}
+
+	return customPlanModifiers
+}
 
 // Equal returns true if the given MapPlanModifiers is the same
 // length, and each of the MapPlanModifier entries is equal.
@@ -23,38 +38,17 @@ func (v MapPlanModifiers) Equal(other MapPlanModifiers) bool {
 		return false
 	}
 
-	var planModifiers MapPlanModifiers
+	planModifiers := v.CustomPlanModifiers()
 
-	var otherPlanModifiers MapPlanModifiers
+	otherPlanModifiers := other.CustomPlanModifiers()
 
-	// Remove nils otherwise sort will panic.
-	for _, planModifier := range v {
-		if planModifier.Custom != nil {
-			planModifiers = append(planModifiers, planModifier)
-		}
-	}
-
-	// Remove nils otherwise sort will panic.
-	for _, planModifier := range other {
-		if planModifier.Custom != nil {
-			otherPlanModifiers = append(otherPlanModifiers, planModifier)
-		}
-	}
-
-	// Compare length after removing nils.
 	if len(planModifiers) != len(otherPlanModifiers) {
 		return false
 	}
 
-	// SchemaDefinition is required by the spec JSON schema.
-	sort.Slice(planModifiers, func(i, j int) bool {
-		return planModifiers[i].Custom.SchemaDefinition < planModifiers[j].Custom.SchemaDefinition
-	})
+	planModifiers.Sort()
 
-	// SchemaDefinition is required by the spec JSON schema.
-	sort.Slice(otherPlanModifiers, func(i, j int) bool {
-		return otherPlanModifiers[i].Custom.SchemaDefinition < otherPlanModifiers[j].Custom.SchemaDefinition
-	})
+	otherPlanModifiers.Sort()
 
 	for k, planModifier := range planModifiers {
 		if !planModifier.Equal(otherPlanModifiers[k]) {

--- a/schema/map_validator.go
+++ b/schema/map_validator.go
@@ -3,10 +3,25 @@
 
 package schema
 
-import "sort"
-
 // MapValidators type defines MapValidator types
 type MapValidators []MapValidator
+
+// CustomValidators returns CustomValidator for each MapValidator.
+func (v MapValidators) CustomValidators() CustomValidators {
+	var customValidators CustomValidators
+
+	for _, validator := range v {
+		customValidator := validator.Custom
+
+		if customValidator == nil {
+			continue
+		}
+
+		customValidators = append(customValidators, customValidator)
+	}
+
+	return customValidators
+}
 
 // Equal returns true if the given MapValidators is the same
 // length, and each of the MapValidator entries is equal.
@@ -23,38 +38,17 @@ func (v MapValidators) Equal(other MapValidators) bool {
 		return false
 	}
 
-	var validators MapValidators
+	validators := v.CustomValidators()
 
-	var otherValidators MapValidators
+	otherValidators := other.CustomValidators()
 
-	// Remove nils otherwise sort will panic.
-	for _, validator := range v {
-		if validator.Custom != nil {
-			validators = append(validators, validator)
-		}
-	}
-
-	// Remove nils otherwise sort will panic.
-	for _, validator := range other {
-		if validator.Custom != nil {
-			otherValidators = append(otherValidators, validator)
-		}
-	}
-
-	// Compare length after removing nils.
 	if len(validators) != len(otherValidators) {
 		return false
 	}
 
-	// SchemaDefinition is required by the spec JSON schema.
-	sort.Slice(validators, func(i, j int) bool {
-		return validators[i].Custom.SchemaDefinition < validators[j].Custom.SchemaDefinition
-	})
+	validators.Sort()
 
-	// SchemaDefinition is required by the spec JSON schema.
-	sort.Slice(otherValidators, func(i, j int) bool {
-		return otherValidators[i].Custom.SchemaDefinition < otherValidators[j].Custom.SchemaDefinition
-	})
+	otherValidators.Sort()
 
 	for k, validator := range validators {
 		if !validator.Equal(otherValidators[k]) {

--- a/schema/number_default.go
+++ b/schema/number_default.go
@@ -10,6 +10,15 @@ type NumberDefault struct {
 	Custom *CustomDefault `json:"custom,omitempty"`
 }
 
+// CustomDefault returns *CustomDefault.
+func (d *NumberDefault) CustomDefault() *CustomDefault {
+	if d == nil {
+		return nil
+	}
+
+	return d.Custom
+}
+
 // Equal returns true if all fields of the given Int64Default are equal.
 func (d *NumberDefault) Equal(other *NumberDefault) bool {
 	if d == nil && other == nil {

--- a/schema/number_plan_modifier.go
+++ b/schema/number_plan_modifier.go
@@ -3,10 +3,25 @@
 
 package schema
 
-import "sort"
-
 // NumberPlanModifiers type defines NumberPlanModifier types
 type NumberPlanModifiers []NumberPlanModifier
+
+// CustomPlanModifiers returns CustomPlanModifier for each NumberPlanModifier.
+func (v NumberPlanModifiers) CustomPlanModifiers() CustomPlanModifiers {
+	var customPlanModifiers CustomPlanModifiers
+
+	for _, planModifier := range v {
+		customPlanModifier := planModifier.Custom
+
+		if customPlanModifier == nil {
+			continue
+		}
+
+		customPlanModifiers = append(customPlanModifiers, customPlanModifier)
+	}
+
+	return customPlanModifiers
+}
 
 // Equal returns true if the given NumberPlanModifiers is the same
 // length, and each of the NumberPlanModifier entries is equal.
@@ -23,38 +38,17 @@ func (v NumberPlanModifiers) Equal(other NumberPlanModifiers) bool {
 		return false
 	}
 
-	var planModifiers NumberPlanModifiers
+	planModifiers := v.CustomPlanModifiers()
 
-	var otherPlanModifiers NumberPlanModifiers
+	otherPlanModifiers := other.CustomPlanModifiers()
 
-	// Remove nils otherwise sort will panic.
-	for _, planModifier := range v {
-		if planModifier.Custom != nil {
-			planModifiers = append(planModifiers, planModifier)
-		}
-	}
-
-	// Remove nils otherwise sort will panic.
-	for _, planModifier := range other {
-		if planModifier.Custom != nil {
-			otherPlanModifiers = append(otherPlanModifiers, planModifier)
-		}
-	}
-
-	// Compare length after removing nils.
 	if len(planModifiers) != len(otherPlanModifiers) {
 		return false
 	}
 
-	// SchemaDefinition is required by the spec JSON schema.
-	sort.Slice(planModifiers, func(i, j int) bool {
-		return planModifiers[i].Custom.SchemaDefinition < planModifiers[j].Custom.SchemaDefinition
-	})
+	planModifiers.Sort()
 
-	// SchemaDefinition is required by the spec JSON schema.
-	sort.Slice(otherPlanModifiers, func(i, j int) bool {
-		return otherPlanModifiers[i].Custom.SchemaDefinition < otherPlanModifiers[j].Custom.SchemaDefinition
-	})
+	otherPlanModifiers.Sort()
 
 	for k, planModifier := range planModifiers {
 		if !planModifier.Equal(otherPlanModifiers[k]) {

--- a/schema/number_validator.go
+++ b/schema/number_validator.go
@@ -3,10 +3,25 @@
 
 package schema
 
-import "sort"
-
 // NumberValidators type defines NumberValidator types
 type NumberValidators []NumberValidator
+
+// CustomValidators returns CustomValidator for each NumberValidator.
+func (v NumberValidators) CustomValidators() CustomValidators {
+	var customValidators CustomValidators
+
+	for _, validator := range v {
+		customValidator := validator.Custom
+
+		if customValidator == nil {
+			continue
+		}
+
+		customValidators = append(customValidators, customValidator)
+	}
+
+	return customValidators
+}
 
 // Equal returns true if the given NumberValidators is the same
 // length, and each of the NumberValidator entries is equal.
@@ -23,38 +38,17 @@ func (v NumberValidators) Equal(other NumberValidators) bool {
 		return false
 	}
 
-	var validators NumberValidators
+	validators := v.CustomValidators()
 
-	var otherValidators NumberValidators
+	otherValidators := other.CustomValidators()
 
-	// Remove nils otherwise sort will panic.
-	for _, validator := range v {
-		if validator.Custom != nil {
-			validators = append(validators, validator)
-		}
-	}
-
-	// Remove nils otherwise sort will panic.
-	for _, validator := range other {
-		if validator.Custom != nil {
-			otherValidators = append(otherValidators, validator)
-		}
-	}
-
-	// Compare length after removing nils.
 	if len(validators) != len(otherValidators) {
 		return false
 	}
 
-	// SchemaDefinition is required by the spec JSON schema.
-	sort.Slice(validators, func(i, j int) bool {
-		return validators[i].Custom.SchemaDefinition < validators[j].Custom.SchemaDefinition
-	})
+	validators.Sort()
 
-	// SchemaDefinition is required by the spec JSON schema.
-	sort.Slice(otherValidators, func(i, j int) bool {
-		return otherValidators[i].Custom.SchemaDefinition < otherValidators[j].Custom.SchemaDefinition
-	})
+	otherValidators.Sort()
 
 	for k, validator := range validators {
 		if !validator.Equal(otherValidators[k]) {

--- a/schema/object_default.go
+++ b/schema/object_default.go
@@ -9,6 +9,15 @@ type ObjectDefault struct {
 	Custom *CustomDefault `json:"custom,omitempty"`
 }
 
+// CustomDefault returns *CustomDefault.
+func (d *ObjectDefault) CustomDefault() *CustomDefault {
+	if d == nil {
+		return nil
+	}
+
+	return d.Custom
+}
+
 // Equal returns true if all fields of the given ObjectDefault are equal.
 func (d *ObjectDefault) Equal(other *ObjectDefault) bool {
 	if d == nil && other == nil {

--- a/schema/object_plan_modifier.go
+++ b/schema/object_plan_modifier.go
@@ -3,10 +3,25 @@
 
 package schema
 
-import "sort"
-
 // ObjectPlanModifiers type defines ObjectPlanModifier types
 type ObjectPlanModifiers []ObjectPlanModifier
+
+// CustomPlanModifiers returns CustomPlanModifier for each ObjectPlanModifier.
+func (v ObjectPlanModifiers) CustomPlanModifiers() CustomPlanModifiers {
+	var customPlanModifiers CustomPlanModifiers
+
+	for _, planModifier := range v {
+		customPlanModifier := planModifier.Custom
+
+		if customPlanModifier == nil {
+			continue
+		}
+
+		customPlanModifiers = append(customPlanModifiers, customPlanModifier)
+	}
+
+	return customPlanModifiers
+}
 
 // Equal returns true if the given ObjectPlanModifiers is the same
 // length, and each of the ObjectPlanModifier entries is equal.
@@ -23,38 +38,17 @@ func (v ObjectPlanModifiers) Equal(other ObjectPlanModifiers) bool {
 		return false
 	}
 
-	var planModifiers ObjectPlanModifiers
+	planModifiers := v.CustomPlanModifiers()
 
-	var otherPlanModifiers ObjectPlanModifiers
+	otherPlanModifiers := other.CustomPlanModifiers()
 
-	// Remove nils otherwise sort will panic.
-	for _, planModifier := range v {
-		if planModifier.Custom != nil {
-			planModifiers = append(planModifiers, planModifier)
-		}
-	}
-
-	// Remove nils otherwise sort will panic.
-	for _, planModifier := range other {
-		if planModifier.Custom != nil {
-			otherPlanModifiers = append(otherPlanModifiers, planModifier)
-		}
-	}
-
-	// Compare length after removing nils.
 	if len(planModifiers) != len(otherPlanModifiers) {
 		return false
 	}
 
-	// SchemaDefinition is required by the spec JSON schema.
-	sort.Slice(planModifiers, func(i, j int) bool {
-		return planModifiers[i].Custom.SchemaDefinition < planModifiers[j].Custom.SchemaDefinition
-	})
+	planModifiers.Sort()
 
-	// SchemaDefinition is required by the spec JSON schema.
-	sort.Slice(otherPlanModifiers, func(i, j int) bool {
-		return otherPlanModifiers[i].Custom.SchemaDefinition < otherPlanModifiers[j].Custom.SchemaDefinition
-	})
+	otherPlanModifiers.Sort()
 
 	for k, planModifier := range planModifiers {
 		if !planModifier.Equal(otherPlanModifiers[k]) {

--- a/schema/set_default.go
+++ b/schema/set_default.go
@@ -9,6 +9,15 @@ type SetDefault struct {
 	Custom *CustomDefault `json:"custom,omitempty"`
 }
 
+// CustomDefault returns *CustomDefault.
+func (d *SetDefault) CustomDefault() *CustomDefault {
+	if d == nil {
+		return nil
+	}
+
+	return d.Custom
+}
+
 // Equal returns true if all fields of the given SetDefault are equal.
 func (d *SetDefault) Equal(other *SetDefault) bool {
 	if d == nil && other == nil {

--- a/schema/set_plan_modifier.go
+++ b/schema/set_plan_modifier.go
@@ -3,10 +3,25 @@
 
 package schema
 
-import "sort"
-
 // SetPlanModifiers type defines SetPlanModifier types
 type SetPlanModifiers []SetPlanModifier
+
+// CustomPlanModifiers returns CustomPlanModifier for each SetPlanModifier.
+func (v SetPlanModifiers) CustomPlanModifiers() CustomPlanModifiers {
+	var customPlanModifiers CustomPlanModifiers
+
+	for _, planModifier := range v {
+		customPlanModifier := planModifier.Custom
+
+		if customPlanModifier == nil {
+			continue
+		}
+
+		customPlanModifiers = append(customPlanModifiers, customPlanModifier)
+	}
+
+	return customPlanModifiers
+}
 
 // Equal returns true if the given SetPlanModifiers is the same
 // length, and each of the SetPlanModifier entries is equal.
@@ -23,38 +38,17 @@ func (v SetPlanModifiers) Equal(other SetPlanModifiers) bool {
 		return false
 	}
 
-	var planModifiers SetPlanModifiers
+	planModifiers := v.CustomPlanModifiers()
 
-	var otherPlanModifiers SetPlanModifiers
+	otherPlanModifiers := other.CustomPlanModifiers()
 
-	// Remove nils otherwise sort will panic.
-	for _, planModifier := range v {
-		if planModifier.Custom != nil {
-			planModifiers = append(planModifiers, planModifier)
-		}
-	}
-
-	// Remove nils otherwise sort will panic.
-	for _, planModifier := range other {
-		if planModifier.Custom != nil {
-			otherPlanModifiers = append(otherPlanModifiers, planModifier)
-		}
-	}
-
-	// Compare length after removing nils.
 	if len(planModifiers) != len(otherPlanModifiers) {
 		return false
 	}
 
-	// SchemaDefinition is required by the spec JSON schema.
-	sort.Slice(planModifiers, func(i, j int) bool {
-		return planModifiers[i].Custom.SchemaDefinition < planModifiers[j].Custom.SchemaDefinition
-	})
+	planModifiers.Sort()
 
-	// SchemaDefinition is required by the spec JSON schema.
-	sort.Slice(otherPlanModifiers, func(i, j int) bool {
-		return otherPlanModifiers[i].Custom.SchemaDefinition < otherPlanModifiers[j].Custom.SchemaDefinition
-	})
+	otherPlanModifiers.Sort()
 
 	for k, planModifier := range planModifiers {
 		if !planModifier.Equal(otherPlanModifiers[k]) {

--- a/schema/set_validator.go
+++ b/schema/set_validator.go
@@ -3,10 +3,25 @@
 
 package schema
 
-import "sort"
-
 // SetValidators type defines SetValidator types
 type SetValidators []SetValidator
+
+// CustomValidators returns CustomValidator for each SetValidator.
+func (v SetValidators) CustomValidators() CustomValidators {
+	var customValidators CustomValidators
+
+	for _, validator := range v {
+		customValidator := validator.Custom
+
+		if customValidator == nil {
+			continue
+		}
+
+		customValidators = append(customValidators, customValidator)
+	}
+
+	return customValidators
+}
 
 // Equal returns true if the given SetValidators is the same
 // length, and each of the SetValidator entries is equal.
@@ -23,38 +38,17 @@ func (v SetValidators) Equal(other SetValidators) bool {
 		return false
 	}
 
-	var validators SetValidators
+	validators := v.CustomValidators()
 
-	var otherValidators SetValidators
+	otherValidators := other.CustomValidators()
 
-	// Remove nils otherwise sort will panic.
-	for _, validator := range v {
-		if validator.Custom != nil {
-			validators = append(validators, validator)
-		}
-	}
-
-	// Remove nils otherwise sort will panic.
-	for _, validator := range other {
-		if validator.Custom != nil {
-			otherValidators = append(otherValidators, validator)
-		}
-	}
-
-	// Compare length after removing nils.
 	if len(validators) != len(otherValidators) {
 		return false
 	}
 
-	// SchemaDefinition is required by the spec JSON schema.
-	sort.Slice(validators, func(i, j int) bool {
-		return validators[i].Custom.SchemaDefinition < validators[j].Custom.SchemaDefinition
-	})
+	validators.Sort()
 
-	// SchemaDefinition is required by the spec JSON schema.
-	sort.Slice(otherValidators, func(i, j int) bool {
-		return otherValidators[i].Custom.SchemaDefinition < otherValidators[j].Custom.SchemaDefinition
-	})
+	otherValidators.Sort()
 
 	for k, validator := range validators {
 		if !validator.Equal(otherValidators[k]) {

--- a/schema/string_plan_modifier.go
+++ b/schema/string_plan_modifier.go
@@ -3,10 +3,25 @@
 
 package schema
 
-import "sort"
-
 // StringPlanModifiers type defines StringPlanModifier types
 type StringPlanModifiers []StringPlanModifier
+
+// CustomPlanModifiers returns CustomPlanModifier for each StringPlanModifier.
+func (v StringPlanModifiers) CustomPlanModifiers() CustomPlanModifiers {
+	var customPlanModifiers CustomPlanModifiers
+
+	for _, planModifier := range v {
+		customPlanModifier := planModifier.Custom
+
+		if customPlanModifier == nil {
+			continue
+		}
+
+		customPlanModifiers = append(customPlanModifiers, customPlanModifier)
+	}
+
+	return customPlanModifiers
+}
 
 // Equal returns true if the given StringPlanModifiers is the same
 // length, and each of the StringPlanModifier entries is equal.
@@ -23,38 +38,17 @@ func (v StringPlanModifiers) Equal(other StringPlanModifiers) bool {
 		return false
 	}
 
-	var planModifiers StringPlanModifiers
+	planModifiers := v.CustomPlanModifiers()
 
-	var otherPlanModifiers StringPlanModifiers
+	otherPlanModifiers := other.CustomPlanModifiers()
 
-	// Remove nils otherwise sort will panic.
-	for _, planModifier := range v {
-		if planModifier.Custom != nil {
-			planModifiers = append(planModifiers, planModifier)
-		}
-	}
-
-	// Remove nils otherwise sort will panic.
-	for _, planModifier := range other {
-		if planModifier.Custom != nil {
-			otherPlanModifiers = append(otherPlanModifiers, planModifier)
-		}
-	}
-
-	// Compare length after removing nils.
 	if len(planModifiers) != len(otherPlanModifiers) {
 		return false
 	}
 
-	// SchemaDefinition is required by the spec JSON schema.
-	sort.Slice(planModifiers, func(i, j int) bool {
-		return planModifiers[i].Custom.SchemaDefinition < planModifiers[j].Custom.SchemaDefinition
-	})
+	planModifiers.Sort()
 
-	// SchemaDefinition is required by the spec JSON schema.
-	sort.Slice(otherPlanModifiers, func(i, j int) bool {
-		return otherPlanModifiers[i].Custom.SchemaDefinition < otherPlanModifiers[j].Custom.SchemaDefinition
-	})
+	otherPlanModifiers.Sort()
 
 	for k, planModifier := range planModifiers {
 		if !planModifier.Equal(otherPlanModifiers[k]) {


### PR DESCRIPTION
These changes are primarily to support updates in [Remove attribute and block schema templates](https://github.com/hashicorp/terraform-plugin-codegen-framework/pull/99#top).

This PR adds convenience functions for obtaining `CustomPlanModifiers` and `CustomValidators` from `PlanModifiers`, and `Validators` types.

Additionally, convenience functions for obtaining `CustomDefault` from list, map, number, object, and set `Default` types have also been added.

For example:

**BoolPlanModifiers**
```go
func (v BoolPlanModifiers) CustomPlanModifiers() CustomPlanModifiers {
	var customPlanModifiers CustomPlanModifiers

	for _, planModifier := range v {
		customPlanModifier := planModifier.Custom

		if customPlanModifier == nil {
			continue
		}

		customPlanModifiers = append(customPlanModifiers, customPlanModifier)
	}

	return customPlanModifiers
}
```

**BoolValidators**
```go
func (v BoolValidators) CustomValidators() CustomValidators {
	var customValidators CustomValidators

	for _, validator := range v {
		customValidator := validator.Custom

		if customValidator == nil {
			continue
		}

		customValidators = append(customValidators, customValidator)
	}

	return customValidators
}
```

**ListDefault**
```go
func (d *ListDefault) CustomDefault() *CustomDefault {
	if d == nil {
		return nil
	}

	return d.Custom
}
```

