### PR TITLE
all: Initial support for dynamic attributes

### DIFF
--- a/.changes/unreleased/FEATURES-20240510-121336.yaml
+++ b/.changes/unreleased/FEATURES-20240510-121336.yaml
@@ -1,0 +1,6 @@
+kind: FEATURES
+body: Initial support of dynamic attributes in data source, provider, and resource
+  schemas
+time: 2024-05-10T12:13:36.019491-04:00
+custom:
+  Issue: "98"

--- a/datasource/attribute.go
+++ b/datasource/attribute.go
@@ -76,6 +76,7 @@ type Attribute struct {
 	Name string `json:"name"`
 
 	Bool         *BoolAttribute         `json:"bool,omitempty"`
+	Dynamic      *DynamicAttribute      `json:"dynamic,omitempty"`
 	Float64      *Float64Attribute      `json:"float64,omitempty"`
 	Int64        *Int64Attribute        `json:"int64,omitempty"`
 	List         *ListAttribute         `json:"list,omitempty"`
@@ -134,6 +135,35 @@ type BoolAttribute struct {
 	// Validators define types and functions that provide validation
 	// functionality for the attribute.
 	Validators schema.BoolValidators `json:"validators,omitempty"`
+}
+
+// DynamicAttribute represents a Schema attribute that is dynamic.
+type DynamicAttribute struct {
+	// AssociatedExternalType defines a Go type that can be used to represent a DynamicAttribute.
+	AssociatedExternalType *schema.AssociatedExternalType `json:"associated_external_type,omitempty"`
+
+	// ComputedOptionalRequired indicates whether the attribute is required
+	// (`required`), optional (`optional`), computed (`computed`), or
+	// computed and optional (`computed_optional`).
+	ComputedOptionalRequired schema.ComputedOptionalRequired `json:"computed_optional_required"`
+
+	// CustomType defines a custom type and value for the attribute.
+	CustomType *schema.CustomType `json:"custom_type,omitempty"`
+
+	// DeprecationMessage defines a message describing that the attribute
+	// is deprecated.
+	DeprecationMessage *string `json:"deprecation_message,omitempty"`
+
+	// Description defines the purpose and usage of the attribute.
+	Description *string `json:"description,omitempty"`
+
+	// Sensitive indicates whether the value of the attribute should
+	// be considered sensitive data.
+	Sensitive *bool `json:"sensitive,omitempty"`
+
+	// Validators define types and functions that provide validation
+	// functionality for the attribute.
+	Validators schema.DynamicValidators `json:"validators,omitempty"`
 }
 
 // Float64Attribute represents a Schema attribute that is a 64-bit

--- a/provider/attribute.go
+++ b/provider/attribute.go
@@ -76,6 +76,7 @@ type Attribute struct {
 	Name string `json:"name"`
 
 	Bool         *BoolAttribute         `json:"bool,omitempty"`
+	Dynamic      *DynamicAttribute      `json:"dynamic,omitempty"`
 	Float64      *Float64Attribute      `json:"float64,omitempty"`
 	Int64        *Int64Attribute        `json:"int64,omitempty"`
 	List         *ListAttribute         `json:"list,omitempty"`
@@ -132,6 +133,34 @@ type BoolAttribute struct {
 	// Validators define types and functions that provide validation
 	// functionality for the block.
 	Validators schema.BoolValidators `json:"validators,omitempty"`
+}
+
+// DynamicAttribute represents a Schema attribute that is dynamic.
+type DynamicAttribute struct {
+	// AssociatedExternalType defines a Go type that can be used to represent a DynamicAttribute.
+	AssociatedExternalType *schema.AssociatedExternalType `json:"associated_external_type,omitempty"`
+
+	// OptionalRequired indicates whether the attribute is required
+	// (`required`), or optional (`optional`).
+	OptionalRequired schema.OptionalRequired `json:"optional_required"`
+
+	// CustomType defines a custom type and value for the attribute.
+	CustomType *schema.CustomType `json:"custom_type,omitempty"`
+
+	// DeprecationMessage defines a message describing that the attribute
+	// is deprecated.
+	DeprecationMessage *string `json:"deprecation_message,omitempty"`
+
+	// Description defines the purpose and usage of the attribute.
+	Description *string `json:"description,omitempty"`
+
+	// Sensitive indicates whether the value of the attribute should
+	// be considered sensitive data.
+	Sensitive *bool `json:"sensitive,omitempty"`
+
+	// Validators define types and functions that provide validation
+	// functionality for the block.
+	Validators schema.DynamicValidators `json:"validators,omitempty"`
 }
 
 // Float64Attribute represents a Schema attribute that is a 64-bit

--- a/resource/attribute.go
+++ b/resource/attribute.go
@@ -76,6 +76,7 @@ type Attribute struct {
 	Name string `json:"name"`
 
 	Bool         *BoolAttribute         `json:"bool,omitempty"`
+	Dynamic      *DynamicAttribute      `json:"dynamic,omitempty"`
 	Float64      *Float64Attribute      `json:"float64,omitempty"`
 	Int64        *Int64Attribute        `json:"int64,omitempty"`
 	List         *ListAttribute         `json:"list,omitempty"`
@@ -145,6 +146,42 @@ type BoolAttribute struct {
 	// Validators define types and functions that provide validation
 	// functionality for the block.
 	Validators schema.BoolValidators `json:"validators,omitempty"`
+}
+
+// DynamicAttribute represents a Schema attribute that is dynamic.
+type DynamicAttribute struct {
+	// AssociatedExternalType defines a Go type that can be used to represent a DynamicAttribute.
+	AssociatedExternalType *schema.AssociatedExternalType `json:"associated_external_type,omitempty"`
+
+	// ComputedOptionalRequired indicates whether the attribute is required
+	// (`required`), optional (`optional`), computed (`computed`), or
+	// computed and optional (`computed_optional`).
+	ComputedOptionalRequired schema.ComputedOptionalRequired `json:"computed_optional_required"`
+
+	// CustomType defines a custom type and value for the attribute.
+	CustomType *schema.CustomType `json:"custom_type,omitempty"`
+
+	// Default defines a default value for the attribute.
+	Default *schema.DynamicDefault `json:"default,omitempty"`
+
+	// DeprecationMessage defines a message describing that the attribute
+	// is deprecated.
+	DeprecationMessage *string `json:"deprecation_message,omitempty"`
+
+	// Description defines the purpose and usage of the attribute.
+	Description *string `json:"description,omitempty"`
+
+	// PlanModifiers define types and functions that provide plan modification
+	// functionality for the attribute.
+	PlanModifiers schema.DynamicPlanModifiers `json:"plan_modifiers,omitempty"`
+
+	// Sensitive indicates whether the value of the attribute should
+	// be considered sensitive data.
+	Sensitive *bool `json:"sensitive,omitempty"`
+
+	// Validators define types and functions that provide validation
+	// functionality for the block.
+	Validators schema.DynamicValidators `json:"validators,omitempty"`
 }
 
 // Float64Attribute represents a Schema attribute that is a 64-bit

--- a/schema/dynamic_default.go
+++ b/schema/dynamic_default.go
@@ -1,0 +1,23 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package schema
+
+// DynamicDefault defines a default dynamic value.
+type DynamicDefault struct {
+	// Custom defines a schema definition, and optional imports.
+	Custom *CustomDefault `json:"custom,omitempty"`
+}
+
+// Equal returns true if all fields of the given DynamicDefault are equal.
+func (d *DynamicDefault) Equal(other *DynamicDefault) bool {
+	if d == nil && other == nil {
+		return true
+	}
+
+	if d == nil || other == nil {
+		return false
+	}
+
+	return d.Custom.Equal(other.Custom)
+}

--- a/schema/dynamic_default_test.go
+++ b/schema/dynamic_default_test.go
@@ -1,0 +1,44 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package schema_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/hashicorp/terraform-plugin-codegen-spec/schema"
+)
+
+func TestDynamicDefault_Equal(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		DynamicDefault *schema.DynamicDefault
+		other          *schema.DynamicDefault
+		expected       bool
+	}{
+		"both_nil": {
+			expected: true,
+		},
+		"dynamic_default_nil_other_not_nil": {
+			other:    &schema.DynamicDefault{},
+			expected: false,
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.DynamicDefault.Equal(testCase.other)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}

--- a/schema/dynamic_plan_modifier.go
+++ b/schema/dynamic_plan_modifier.go
@@ -1,0 +1,72 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package schema
+
+// DynamicPlanModifiers type defines DynamicPlanModifier types
+type DynamicPlanModifiers []DynamicPlanModifier
+
+// CustomPlanModifiers returns CustomPlanModifier for each DynamicPlanModifier.
+func (v DynamicPlanModifiers) CustomPlanModifiers() CustomPlanModifiers {
+	var customPlanModifiers CustomPlanModifiers
+
+	for _, planModifier := range v {
+		customPlanModifier := planModifier.Custom
+
+		if customPlanModifier == nil {
+			continue
+		}
+
+		customPlanModifiers = append(customPlanModifiers, customPlanModifier)
+	}
+
+	return customPlanModifiers
+}
+
+// Equal returns true if the given DynamicPlanModifiers is the same
+// length, and each of the DynamicPlanModifier entries is equal.
+func (v DynamicPlanModifiers) Equal(other DynamicPlanModifiers) bool {
+	if v == nil && other == nil {
+		return true
+	}
+
+	if v == nil || other == nil {
+		return false
+	}
+
+	if len(v) != len(other) {
+		return false
+	}
+
+	planModifiers := v.CustomPlanModifiers()
+
+	otherPlanModifiers := other.CustomPlanModifiers()
+
+	if len(planModifiers) != len(otherPlanModifiers) {
+		return false
+	}
+
+	planModifiers.Sort()
+
+	otherPlanModifiers.Sort()
+
+	for k, planModifier := range planModifiers {
+		if !planModifier.Equal(otherPlanModifiers[k]) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// DynamicPlanModifier type defines type and function that provides plan modification
+// functionality.
+type DynamicPlanModifier struct {
+	// Custom defines a schema definition, and optional imports.
+	Custom *CustomPlanModifier `json:"custom,omitempty"`
+}
+
+// Equal returns true if the fields of the given DynamicPlanModifier are equal.
+func (v DynamicPlanModifier) Equal(other DynamicPlanModifier) bool {
+	return v.Custom.Equal(other.Custom)
+}

--- a/schema/dynamic_plan_modifier_test.go
+++ b/schema/dynamic_plan_modifier_test.go
@@ -1,0 +1,139 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package schema_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/hashicorp/terraform-plugin-codegen-spec/schema"
+)
+
+func TestDynamicPlanModifiers_Equal(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		planModifiers schema.DynamicPlanModifiers
+		other         schema.DynamicPlanModifiers
+		expected      bool
+	}{
+		"plan_modifiers_both_nil": {
+			expected: true,
+		},
+		"plan_modifiers_nil_other_not_nil": {
+			other: schema.DynamicPlanModifiers{
+				schema.DynamicPlanModifier{},
+			},
+			expected: false,
+		},
+		"plan_modifiers_not_nil_other_nil": {
+			planModifiers: schema.DynamicPlanModifiers{
+				schema.DynamicPlanModifier{},
+			},
+			expected: false,
+		},
+		"plan_modifiers_len_diff": {
+			planModifiers: schema.DynamicPlanModifiers{
+				schema.DynamicPlanModifier{
+					Custom: &schema.CustomPlanModifier{},
+				},
+			},
+			other:    schema.DynamicPlanModifiers{},
+			expected: false,
+		},
+		"plan_modifiers_len_same": {
+			planModifiers: schema.DynamicPlanModifiers{
+				schema.DynamicPlanModifier{
+					Custom: &schema.CustomPlanModifier{},
+				},
+			},
+			other: schema.DynamicPlanModifiers{
+				schema.DynamicPlanModifier{
+					Custom: &schema.CustomPlanModifier{},
+				},
+			},
+			expected: true,
+		},
+		"plan_modifiers_len_same_with_custom_nils": {
+			planModifiers: schema.DynamicPlanModifiers{
+				schema.DynamicPlanModifier{},
+			},
+			other: schema.DynamicPlanModifiers{
+				schema.DynamicPlanModifier{
+					Custom: &schema.CustomPlanModifier{},
+				},
+			},
+			expected: false,
+		},
+		"plan_modifiers_schema_definition_same_order": {
+			planModifiers: schema.DynamicPlanModifiers{
+				{
+					Custom: &schema.CustomPlanModifier{
+						SchemaDefinition: "one",
+					},
+				},
+				{
+					Custom: &schema.CustomPlanModifier{
+						SchemaDefinition: "two",
+					},
+				},
+			},
+			other: schema.DynamicPlanModifiers{
+				{
+					Custom: &schema.CustomPlanModifier{
+						SchemaDefinition: "one",
+					},
+				},
+				{
+					Custom: &schema.CustomPlanModifier{
+						SchemaDefinition: "two",
+					},
+				},
+			},
+			expected: true,
+		},
+		"plan_modifiers_schema_definition_different_order": {
+			planModifiers: schema.DynamicPlanModifiers{
+				{
+					Custom: &schema.CustomPlanModifier{
+						SchemaDefinition: "two",
+					},
+				},
+				{
+					Custom: &schema.CustomPlanModifier{
+						SchemaDefinition: "one",
+					},
+				},
+			},
+			other: schema.DynamicPlanModifiers{
+				{
+					Custom: &schema.CustomPlanModifier{
+						SchemaDefinition: "one",
+					},
+				},
+				{
+					Custom: &schema.CustomPlanModifier{
+						SchemaDefinition: "two",
+					},
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.planModifiers.Equal(testCase.other)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}

--- a/schema/dynamic_type.go
+++ b/schema/dynamic_type.go
@@ -1,0 +1,10 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package schema
+
+// DynamicType is a representation of dynamic type.
+type DynamicType struct {
+	// CustomType is a customization of the DynamicType.
+	CustomType *CustomType `json:"custom_type,omitempty"`
+}

--- a/schema/dynamic_validator.go
+++ b/schema/dynamic_validator.go
@@ -1,0 +1,72 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package schema
+
+// DynamicValidators type is a slice of DynamicValidator.
+type DynamicValidators []DynamicValidator
+
+// CustomValidators returns CustomValidator for each DynamicValidator.
+func (v DynamicValidators) CustomValidators() CustomValidators {
+	var customValidators CustomValidators
+
+	for _, validator := range v {
+		customValidator := validator.Custom
+
+		if customValidator == nil {
+			continue
+		}
+
+		customValidators = append(customValidators, customValidator)
+	}
+
+	return customValidators
+}
+
+// Equal returns true if the given DynamicValidators is the same
+// length, and each of the DynamicValidator entries is equal.
+func (v DynamicValidators) Equal(other DynamicValidators) bool {
+	if v == nil && other == nil {
+		return true
+	}
+
+	if v == nil || other == nil {
+		return false
+	}
+
+	if len(v) != len(other) {
+		return false
+	}
+
+	validators := v.CustomValidators()
+
+	otherValidators := other.CustomValidators()
+
+	if len(validators) != len(otherValidators) {
+		return false
+	}
+
+	validators.Sort()
+
+	otherValidators.Sort()
+
+	for k, validator := range validators {
+		if !validator.Equal(otherValidators[k]) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// DynamicValidator type defines type and function that provides validation
+// functionality.
+type DynamicValidator struct {
+	// Custom defines a schema definition, and optional imports.
+	Custom *CustomValidator `json:"custom,omitempty"`
+}
+
+// Equal returns true if the fields of the given DynamicValidator equal.
+func (v DynamicValidator) Equal(other DynamicValidator) bool {
+	return v.Custom.Equal(other.Custom)
+}

--- a/schema/dynamic_validator_test.go
+++ b/schema/dynamic_validator_test.go
@@ -1,0 +1,139 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package schema_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/hashicorp/terraform-plugin-codegen-spec/schema"
+)
+
+func TestDynamicValidators_Equal(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		validators schema.DynamicValidators
+		other      schema.DynamicValidators
+		expected   bool
+	}{
+		"validators_both_nil": {
+			expected: true,
+		},
+		"validators_nil_other_not_nil": {
+			other: schema.DynamicValidators{
+				schema.DynamicValidator{},
+			},
+			expected: false,
+		},
+		"validators_not_nil_other_nil": {
+			validators: schema.DynamicValidators{
+				schema.DynamicValidator{},
+			},
+			expected: false,
+		},
+		"validators_len_diff": {
+			validators: schema.DynamicValidators{
+				schema.DynamicValidator{
+					Custom: &schema.CustomValidator{},
+				},
+			},
+			other:    schema.DynamicValidators{},
+			expected: false,
+		},
+		"validators_len_same": {
+			validators: schema.DynamicValidators{
+				schema.DynamicValidator{
+					Custom: &schema.CustomValidator{},
+				},
+			},
+			other: schema.DynamicValidators{
+				schema.DynamicValidator{
+					Custom: &schema.CustomValidator{},
+				},
+			},
+			expected: true,
+		},
+		"validators_len_same_with_custom_nils": {
+			validators: schema.DynamicValidators{
+				schema.DynamicValidator{},
+			},
+			other: schema.DynamicValidators{
+				schema.DynamicValidator{
+					Custom: &schema.CustomValidator{},
+				},
+			},
+			expected: false,
+		},
+		"validators_schema_definition_same_order": {
+			validators: schema.DynamicValidators{
+				{
+					Custom: &schema.CustomValidator{
+						SchemaDefinition: "one",
+					},
+				},
+				{
+					Custom: &schema.CustomValidator{
+						SchemaDefinition: "two",
+					},
+				},
+			},
+			other: schema.DynamicValidators{
+				{
+					Custom: &schema.CustomValidator{
+						SchemaDefinition: "one",
+					},
+				},
+				{
+					Custom: &schema.CustomValidator{
+						SchemaDefinition: "two",
+					},
+				},
+			},
+			expected: true,
+		},
+		"validators_schema_definition_different_order": {
+			validators: schema.DynamicValidators{
+				{
+					Custom: &schema.CustomValidator{
+						SchemaDefinition: "two",
+					},
+				},
+				{
+					Custom: &schema.CustomValidator{
+						SchemaDefinition: "one",
+					},
+				},
+			},
+			other: schema.DynamicValidators{
+				{
+					Custom: &schema.CustomValidator{
+						SchemaDefinition: "one",
+					},
+				},
+				{
+					Custom: &schema.CustomValidator{
+						SchemaDefinition: "two",
+					},
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for name, testCase := range testCases {
+		name, testCase := name, testCase
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := testCase.validators.Equal(testCase.other)
+
+			if diff := cmp.Diff(got, testCase.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
+			}
+		})
+	}
+}

--- a/schema/element_type.go
+++ b/schema/element_type.go
@@ -4,6 +4,10 @@
 package schema
 
 // ElementType defines the type within a list, map, or set.
+//
+// DynamicType is intentionally not supported as it can cause confusing behavior
+// or unavoidable errors for practitioners if elements cannot be conformed into
+// a single element type.
 type ElementType struct {
 	Bool    *BoolType    `json:"bool,omitempty"`
 	Float64 *Float64Type `json:"float64,omitempty"`

--- a/schema/object_attribute_type.go
+++ b/schema/object_attribute_type.go
@@ -77,6 +77,7 @@ type ObjectAttributeType struct {
 	Name string `json:"name"`
 
 	Bool    *BoolType    `json:"bool,omitempty"`
+	Dynamic *DynamicType `json:"dynamic,omitempty"`
 	Float64 *Float64Type `json:"float64,omitempty"`
 	Int64   *Int64Type   `json:"int64,omitempty"`
 	List    *ListType    `json:"list,omitempty"`
@@ -103,6 +104,18 @@ func (o ObjectAttributeType) Equal(other ObjectAttributeType) bool {
 
 	if o.Bool != nil && other.Bool != nil {
 		return o.Bool.CustomType.Equal(other.Bool.CustomType)
+	}
+
+	if o.Dynamic == nil && other.Dynamic != nil {
+		return false
+	}
+
+	if o.Dynamic != nil && other.Dynamic == nil {
+		return false
+	}
+
+	if o.Dynamic != nil && other.Dynamic != nil {
+		return o.Dynamic.CustomType.Equal(other.Dynamic.CustomType)
 	}
 
 	if o.Float64 == nil && other.Float64 != nil {

--- a/schema/object_attribute_type_test.go
+++ b/schema/object_attribute_type_test.go
@@ -90,6 +90,18 @@ func TestObjectAttributeType_Equal(t *testing.T) {
 			},
 			expected: false,
 		},
+		"dynamic_nil_other_not_nil": {
+			other: schema.ObjectAttributeType{
+				Dynamic: &schema.DynamicType{},
+			},
+			expected: false,
+		},
+		"dynamic_not_nil_other_nil": {
+			objectAttributeType: schema.ObjectAttributeType{
+				Dynamic: &schema.DynamicType{},
+			},
+			expected: false,
+		},
 		"float64_nil_other_not_nil": {
 			other: schema.ObjectAttributeType{
 				Float64: &schema.Float64Type{},

--- a/spec/specification_test.go
+++ b/spec/specification_test.go
@@ -126,6 +126,69 @@ func TestSpecification_JSONUnmarshal_Version0_1(t *testing.T) {
 									},
 								},
 								{
+									Name: "dynamic_attribute",
+									Dynamic: &datasource.DynamicAttribute{
+										ComputedOptionalRequired: schema.Computed,
+									},
+								},
+								{
+									Name: "dynamic_attribute_associated_external_type",
+									Dynamic: &datasource.DynamicAttribute{
+										AssociatedExternalType: &schema.AssociatedExternalType{
+											Import: &code.Import{
+												Path: "example.com/apisdk",
+											},
+											Type: "*apisdk.Type",
+										},
+										ComputedOptionalRequired: schema.Computed,
+									},
+								},
+								{
+									Name: "dynamic_attribute_custom_type",
+									Dynamic: &datasource.DynamicAttribute{
+										ComputedOptionalRequired: schema.Computed,
+										CustomType: &schema.CustomType{
+											Import: &code.Import{
+												Path: "github.com/hashicorp/terraform-plugin-framework/types/basetypes",
+											},
+											Type:      "basetypes.DynamicType",
+											ValueType: "basetypes.DynamicValue",
+										},
+									},
+								},
+								{
+									Name: "dynamic_attribute_custom_type_import_alias",
+									Dynamic: &datasource.DynamicAttribute{
+										ComputedOptionalRequired: schema.Computed,
+										CustomType: &schema.CustomType{
+											Import: &code.Import{
+												Alias: pointer("fwtype"),
+												Path:  "github.com/hashicorp/terraform-plugin-framework/types/basetypes",
+											},
+											Type:      "fwtype.DynamicType",
+											ValueType: "fwtype.DynamicValue",
+										},
+									},
+								},
+								{
+									Name: "dynamic_attribute_validators",
+									Dynamic: &datasource.DynamicAttribute{
+										ComputedOptionalRequired: schema.Optional,
+										Validators: schema.DynamicValidators{
+											{
+												Custom: &schema.CustomValidator{
+													Imports: []code.Import{
+														{
+															Path: "github.com/my_account/my_project/mydynamicvalidator",
+														},
+													},
+													SchemaDefinition: "mydynamicvalidator.Validate()",
+												},
+											},
+										},
+									},
+								},
+								{
 									Name: "float64_attribute",
 									Float64: &datasource.Float64Attribute{
 										ComputedOptionalRequired: schema.Computed,
@@ -1140,6 +1203,69 @@ func TestSpecification_JSONUnmarshal_Version0_1(t *testing.T) {
 										Type: "*apisdk.Type",
 									},
 									OptionalRequired: schema.Optional,
+								},
+							},
+							{
+								Name: "dynamic_attribute",
+								Dynamic: &provider.DynamicAttribute{
+									OptionalRequired: schema.Optional,
+								},
+							},
+							{
+								Name: "dynamic_attribute_associated_external_type",
+								Dynamic: &provider.DynamicAttribute{
+									AssociatedExternalType: &schema.AssociatedExternalType{
+										Import: &code.Import{
+											Path: "example.com/apisdk",
+										},
+										Type: "*apisdk.Type",
+									},
+									OptionalRequired: schema.Optional,
+								},
+							},
+							{
+								Name: "dynamic_attribute_custom_type",
+								Dynamic: &provider.DynamicAttribute{
+									OptionalRequired: schema.Optional,
+									CustomType: &schema.CustomType{
+										Import: &code.Import{
+											Path: "github.com/hashicorp/terraform-plugin-framework/types/basetypes",
+										},
+										Type:      "basetypes.DynamicType",
+										ValueType: "basetypes.DynamicValue",
+									},
+								},
+							},
+							{
+								Name: "dynamic_attribute_custom_type_import_alias",
+								Dynamic: &provider.DynamicAttribute{
+									OptionalRequired: schema.Optional,
+									CustomType: &schema.CustomType{
+										Import: &code.Import{
+											Alias: pointer("fwtype"),
+											Path:  "github.com/hashicorp/terraform-plugin-framework/types/basetypes",
+										},
+										Type:      "fwtype.DynamicType",
+										ValueType: "fwtype.DynamicValue",
+									},
+								},
+							},
+							{
+								Name: "dynamic_attribute_validators",
+								Dynamic: &provider.DynamicAttribute{
+									OptionalRequired: schema.Optional,
+									Validators: schema.DynamicValidators{
+										{
+											Custom: &schema.CustomValidator{
+												Imports: []code.Import{
+													{
+														Path: "github.com/my_account/my_project/mydynamicvalidator",
+													},
+												},
+												SchemaDefinition: "mydynamicvalidator.Validate()",
+											},
+										},
+									},
 								},
 							},
 							{
@@ -2190,6 +2316,106 @@ func TestSpecification_JSONUnmarshal_Version0_1(t *testing.T) {
 											Type: "*apisdk.Type",
 										},
 										ComputedOptionalRequired: schema.Optional,
+									},
+								},
+								{
+									Name: "dynamic_attribute",
+									Dynamic: &resource.DynamicAttribute{
+										ComputedOptionalRequired: schema.Computed,
+									},
+								},
+								{
+									Name: "dynamic_attribute_associated_external_type",
+									Dynamic: &resource.DynamicAttribute{
+										AssociatedExternalType: &schema.AssociatedExternalType{
+											Import: &code.Import{
+												Path: "example.com/apisdk",
+											},
+											Type: "*apisdk.Type",
+										},
+										ComputedOptionalRequired: schema.Optional,
+									},
+								},
+								{
+									Name: "dynamic_attribute_custom_type",
+									Dynamic: &resource.DynamicAttribute{
+										ComputedOptionalRequired: schema.Computed,
+										CustomType: &schema.CustomType{
+											Import: &code.Import{
+												Path: "github.com/hashicorp/terraform-plugin-framework/types/basetypes",
+											},
+											Type:      "basetypes.DynamicType",
+											ValueType: "basetypes.DynamicValue",
+										},
+									},
+								},
+								{
+									Name: "dynamic_attribute_custom_type_import_alias",
+									Dynamic: &resource.DynamicAttribute{
+										ComputedOptionalRequired: schema.Computed,
+										CustomType: &schema.CustomType{
+											Import: &code.Import{
+												Alias: pointer("fwtype"),
+												Path:  "github.com/hashicorp/terraform-plugin-framework/types/basetypes",
+											},
+											Type:      "fwtype.DynamicType",
+											ValueType: "fwtype.DynamicValue",
+										},
+									},
+								},
+								{
+									Name: "dynamic_attribute_default",
+									Dynamic: &resource.DynamicAttribute{
+										ComputedOptionalRequired: schema.Optional,
+										Default: &schema.DynamicDefault{
+											Custom: &schema.CustomDefault{
+												Imports: []code.Import{
+													{
+														Path: "github.com/hashicorp/terraform-plugin-framework/resource/schema/dynamicdefault",
+													},
+													{
+														Path: "github.com/hashicorp/terraform-plugin-framework/types",
+													},
+												},
+												SchemaDefinition: "dynamicdefault.StaticValue(types.StringValue(\"example\"))",
+											},
+										},
+									},
+								},
+								{
+									Name: "dynamic_attribute_plan_modifiers",
+									Dynamic: &resource.DynamicAttribute{
+										ComputedOptionalRequired: schema.Computed,
+										PlanModifiers: schema.DynamicPlanModifiers{
+											{
+												Custom: &schema.CustomPlanModifier{
+													Imports: []code.Import{
+														{
+															Path: "github.com/my_account/my_project/dynamicplanmodifier",
+														},
+													},
+													SchemaDefinition: "mydynamicplanmodifier.Modify()",
+												},
+											},
+										},
+									},
+								},
+								{
+									Name: "dynamic_attribute_validators",
+									Dynamic: &resource.DynamicAttribute{
+										ComputedOptionalRequired: schema.Computed,
+										Validators: schema.DynamicValidators{
+											{
+												Custom: &schema.CustomValidator{
+													Imports: []code.Import{
+														{
+															Path: "github.com/my_account/my_project/mydynamicvalidator",
+														},
+													},
+													SchemaDefinition: "mydynamicvalidator.Validate()",
+												},
+											},
+										},
 									},
 								},
 								{
@@ -5704,6 +5930,69 @@ func TestSpecification_Generate_Version0_1(t *testing.T) {
 									},
 								},
 								{
+									Name: "dynamic_attribute",
+									Dynamic: &datasource.DynamicAttribute{
+										ComputedOptionalRequired: schema.Computed,
+									},
+								},
+								{
+									Name: "dynamic_attribute_associated_external_type",
+									Dynamic: &datasource.DynamicAttribute{
+										AssociatedExternalType: &schema.AssociatedExternalType{
+											Import: &code.Import{
+												Path: "example.com/apisdk",
+											},
+											Type: "*apisdk.Type",
+										},
+										ComputedOptionalRequired: schema.Computed,
+									},
+								},
+								{
+									Name: "dynamic_attribute_custom_type",
+									Dynamic: &datasource.DynamicAttribute{
+										ComputedOptionalRequired: schema.Computed,
+										CustomType: &schema.CustomType{
+											Import: &code.Import{
+												Path: "github.com/hashicorp/terraform-plugin-framework/types/basetypes",
+											},
+											Type:      "basetypes.DynamicType",
+											ValueType: "basetypes.DynamicValue",
+										},
+									},
+								},
+								{
+									Name: "dynamic_attribute_custom_type_import_alias",
+									Dynamic: &datasource.DynamicAttribute{
+										ComputedOptionalRequired: schema.Computed,
+										CustomType: &schema.CustomType{
+											Import: &code.Import{
+												Alias: pointer("fwtype"),
+												Path:  "github.com/hashicorp/terraform-plugin-framework/types/basetypes",
+											},
+											Type:      "fwtype.DynamicType",
+											ValueType: "fwtype.DynamicValue",
+										},
+									},
+								},
+								{
+									Name: "dynamic_attribute_validators",
+									Dynamic: &datasource.DynamicAttribute{
+										ComputedOptionalRequired: schema.Optional,
+										Validators: schema.DynamicValidators{
+											{
+												Custom: &schema.CustomValidator{
+													Imports: []code.Import{
+														{
+															Path: "github.com/my_account/my_project/mydynamicvalidator",
+														},
+													},
+													SchemaDefinition: "mydynamicvalidator.Validate()",
+												},
+											},
+										},
+									},
+								},
+								{
 									Name: "float64_attribute",
 									Float64: &datasource.Float64Attribute{
 										ComputedOptionalRequired: schema.Computed,
@@ -6718,6 +7007,69 @@ func TestSpecification_Generate_Version0_1(t *testing.T) {
 										Type: "*apisdk.Type",
 									},
 									OptionalRequired: schema.Optional,
+								},
+							},
+							{
+								Name: "dynamic_attribute",
+								Dynamic: &provider.DynamicAttribute{
+									OptionalRequired: schema.Optional,
+								},
+							},
+							{
+								Name: "dynamic_attribute_associated_external_type",
+								Dynamic: &provider.DynamicAttribute{
+									AssociatedExternalType: &schema.AssociatedExternalType{
+										Import: &code.Import{
+											Path: "example.com/apisdk",
+										},
+										Type: "*apisdk.Type",
+									},
+									OptionalRequired: schema.Optional,
+								},
+							},
+							{
+								Name: "dynamic_attribute_custom_type",
+								Dynamic: &provider.DynamicAttribute{
+									OptionalRequired: schema.Optional,
+									CustomType: &schema.CustomType{
+										Import: &code.Import{
+											Path: "github.com/hashicorp/terraform-plugin-framework/types/basetypes",
+										},
+										Type:      "basetypes.DynamicType",
+										ValueType: "basetypes.DynamicValue",
+									},
+								},
+							},
+							{
+								Name: "dynamic_attribute_custom_type_import_alias",
+								Dynamic: &provider.DynamicAttribute{
+									OptionalRequired: schema.Optional,
+									CustomType: &schema.CustomType{
+										Import: &code.Import{
+											Alias: pointer("fwtype"),
+											Path:  "github.com/hashicorp/terraform-plugin-framework/types/basetypes",
+										},
+										Type:      "fwtype.DynamicType",
+										ValueType: "fwtype.DynamicValue",
+									},
+								},
+							},
+							{
+								Name: "dynamic_attribute_validators",
+								Dynamic: &provider.DynamicAttribute{
+									OptionalRequired: schema.Optional,
+									Validators: schema.DynamicValidators{
+										{
+											Custom: &schema.CustomValidator{
+												Imports: []code.Import{
+													{
+														Path: "github.com/my_account/my_project/mydynamicvalidator",
+													},
+												},
+												SchemaDefinition: "mydynamicvalidator.Validate()",
+											},
+										},
+									},
 								},
 							},
 							{
@@ -7768,6 +8120,106 @@ func TestSpecification_Generate_Version0_1(t *testing.T) {
 											Type: "*apisdk.Type",
 										},
 										ComputedOptionalRequired: schema.Optional,
+									},
+								},
+								{
+									Name: "dynamic_attribute",
+									Dynamic: &resource.DynamicAttribute{
+										ComputedOptionalRequired: schema.Computed,
+									},
+								},
+								{
+									Name: "dynamic_attribute_associated_external_type",
+									Dynamic: &resource.DynamicAttribute{
+										AssociatedExternalType: &schema.AssociatedExternalType{
+											Import: &code.Import{
+												Path: "example.com/apisdk",
+											},
+											Type: "*apisdk.Type",
+										},
+										ComputedOptionalRequired: schema.Optional,
+									},
+								},
+								{
+									Name: "dynamic_attribute_custom_type",
+									Dynamic: &resource.DynamicAttribute{
+										ComputedOptionalRequired: schema.Computed,
+										CustomType: &schema.CustomType{
+											Import: &code.Import{
+												Path: "github.com/hashicorp/terraform-plugin-framework/types/basetypes",
+											},
+											Type:      "basetypes.DynamicType",
+											ValueType: "basetypes.DynamicValue",
+										},
+									},
+								},
+								{
+									Name: "dynamic_attribute_custom_type_import_alias",
+									Dynamic: &resource.DynamicAttribute{
+										ComputedOptionalRequired: schema.Computed,
+										CustomType: &schema.CustomType{
+											Import: &code.Import{
+												Alias: pointer("fwtype"),
+												Path:  "github.com/hashicorp/terraform-plugin-framework/types/basetypes",
+											},
+											Type:      "fwtype.DynamicType",
+											ValueType: "fwtype.DynamicValue",
+										},
+									},
+								},
+								{
+									Name: "dynamic_attribute_default",
+									Dynamic: &resource.DynamicAttribute{
+										ComputedOptionalRequired: schema.Optional,
+										Default: &schema.DynamicDefault{
+											Custom: &schema.CustomDefault{
+												Imports: []code.Import{
+													{
+														Path: "github.com/hashicorp/terraform-plugin-framework/resource/schema/dynamicdefault",
+													},
+													{
+														Path: "github.com/hashicorp/terraform-plugin-framework/types",
+													},
+												},
+												SchemaDefinition: "dynamicdefault.StaticValue(types.StringValue(\"example\"))",
+											},
+										},
+									},
+								},
+								{
+									Name: "dynamic_attribute_plan_modifiers",
+									Dynamic: &resource.DynamicAttribute{
+										ComputedOptionalRequired: schema.Computed,
+										PlanModifiers: schema.DynamicPlanModifiers{
+											{
+												Custom: &schema.CustomPlanModifier{
+													Imports: []code.Import{
+														{
+															Path: "github.com/my_account/my_project/dynamicplanmodifier",
+														},
+													},
+													SchemaDefinition: "mydynamicplanmodifier.Modify()",
+												},
+											},
+										},
+									},
+								},
+								{
+									Name: "dynamic_attribute_validators",
+									Dynamic: &resource.DynamicAttribute{
+										ComputedOptionalRequired: schema.Computed,
+										Validators: schema.DynamicValidators{
+											{
+												Custom: &schema.CustomValidator{
+													Imports: []code.Import{
+														{
+															Path: "github.com/my_account/my_project/mydynamicvalidator",
+														},
+													},
+													SchemaDefinition: "mydynamicvalidator.Validate()",
+												},
+											},
+										},
 									},
 								},
 								{

--- a/spec/specification_test.go
+++ b/spec/specification_test.go
@@ -498,6 +498,18 @@ func TestSpecification_JSONUnmarshal_Version0_1(t *testing.T) {
 									},
 								},
 								{
+									Name: "object_attribute_attribute_types_dynamic",
+									Object: &datasource.ObjectAttribute{
+										AttributeTypes: []schema.ObjectAttributeType{
+											{
+												Name:    "object_dynamic_attribute",
+												Dynamic: &schema.DynamicType{},
+											},
+										},
+										ComputedOptionalRequired: schema.Computed,
+									},
+								},
+								{
 									Name: "object_attribute_attribute_types_object_custom_type",
 									Object: &datasource.ObjectAttribute{
 										AttributeTypes: []schema.ObjectAttributeType{
@@ -1572,6 +1584,18 @@ func TestSpecification_JSONUnmarshal_Version0_1(t *testing.T) {
 										{
 											Name:   "obj_string_attr",
 											String: &schema.StringType{},
+										},
+									},
+									OptionalRequired: schema.Optional,
+								},
+							},
+							{
+								Name: "object_attribute_attribute_types_dynamic",
+								Object: &provider.ObjectAttribute{
+									AttributeTypes: []schema.ObjectAttributeType{
+										{
+											Name:    "object_dynamic_attribute",
+											Dynamic: &schema.DynamicType{},
 										},
 									},
 									OptionalRequired: schema.Optional,
@@ -2784,6 +2808,18 @@ func TestSpecification_JSONUnmarshal_Version0_1(t *testing.T) {
 											{
 												Name:   "obj_string_attr",
 												String: &schema.StringType{},
+											},
+										},
+										ComputedOptionalRequired: schema.Computed,
+									},
+								},
+								{
+									Name: "object_attribute_attribute_types_dynamic",
+									Object: &resource.ObjectAttribute{
+										AttributeTypes: []schema.ObjectAttributeType{
+											{
+												Name:    "object_dynamic_attribute",
+												Dynamic: &schema.DynamicType{},
 											},
 										},
 										ComputedOptionalRequired: schema.Computed,
@@ -6302,6 +6338,18 @@ func TestSpecification_Generate_Version0_1(t *testing.T) {
 									},
 								},
 								{
+									Name: "object_attribute_attribute_types_dynamic",
+									Object: &datasource.ObjectAttribute{
+										AttributeTypes: []schema.ObjectAttributeType{
+											{
+												Name:    "object_dynamic_attribute",
+												Dynamic: &schema.DynamicType{},
+											},
+										},
+										ComputedOptionalRequired: schema.Computed,
+									},
+								},
+								{
 									Name: "object_attribute_attribute_types_object_custom_type",
 									Object: &datasource.ObjectAttribute{
 										AttributeTypes: []schema.ObjectAttributeType{
@@ -7376,6 +7424,18 @@ func TestSpecification_Generate_Version0_1(t *testing.T) {
 										{
 											Name:   "obj_string_attr",
 											String: &schema.StringType{},
+										},
+									},
+									OptionalRequired: schema.Optional,
+								},
+							},
+							{
+								Name: "object_attribute_attribute_types_dynamic",
+								Object: &provider.ObjectAttribute{
+									AttributeTypes: []schema.ObjectAttributeType{
+										{
+											Name:    "object_dynamic_attribute",
+											Dynamic: &schema.DynamicType{},
 										},
 									},
 									OptionalRequired: schema.Optional,
@@ -8588,6 +8648,18 @@ func TestSpecification_Generate_Version0_1(t *testing.T) {
 											{
 												Name:   "obj_string_attr",
 												String: &schema.StringType{},
+											},
+										},
+										ComputedOptionalRequired: schema.Computed,
+									},
+								},
+								{
+									Name: "object_attribute_attribute_types_dynamic",
+									Object: &resource.ObjectAttribute{
+										AttributeTypes: []schema.ObjectAttributeType{
+											{
+												Name:    "object_dynamic_attribute",
+												Dynamic: &schema.DynamicType{},
 											},
 										},
 										ComputedOptionalRequired: schema.Computed,

--- a/spec/v0.1/example.json
+++ b/spec/v0.1/example.json
@@ -50,6 +50,69 @@
             }
           },
           {
+            "name": "dynamic_attribute",
+            "dynamic": {
+              "computed_optional_required": "computed"
+            }
+          },
+          {
+            "name": "dynamic_attribute_associated_external_type",
+            "dynamic": {
+              "associated_external_type": {
+                "import": {
+                  "path": "example.com/apisdk"
+                },
+                "type": "*apisdk.Type"
+              },
+              "computed_optional_required": "computed"
+            }
+          },
+          {
+            "name": "dynamic_attribute_custom_type",
+            "dynamic": {
+              "computed_optional_required": "computed",
+              "custom_type": {
+                "import": {
+                  "path": "github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+                },
+                "type": "basetypes.DynamicType",
+                "value_type": "basetypes.DynamicValue"
+              }
+            }
+          },
+          {
+            "name": "dynamic_attribute_custom_type_import_alias",
+            "dynamic": {
+              "computed_optional_required": "computed",
+              "custom_type": {
+                "import": {
+                  "alias": "fwtype",
+                  "path": "github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+                },
+                "type": "fwtype.DynamicType",
+                "value_type": "fwtype.DynamicValue"
+              }
+            }
+          },
+          {
+            "name": "dynamic_attribute_validators",
+            "dynamic": {
+              "computed_optional_required": "optional",
+              "validators": [
+                {
+                  "custom": {
+                    "imports": [
+                      {
+                        "path": "github.com/my_account/my_project/mydynamicvalidator"
+                      }
+                    ],
+                    "schema_definition": "mydynamicvalidator.Validate()"
+                  }
+                }
+              ]
+            }
+          },
+          {
             "name": "float64_attribute",
             "float64": {
               "computed_optional_required": "computed"
@@ -1064,6 +1127,69 @@
               "type": "*apisdk.Type"
             },
             "optional_required": "optional"
+          }
+        },
+        {
+          "name": "dynamic_attribute",
+          "dynamic": {
+            "optional_required": "optional"
+          }
+        },
+        {
+          "name": "dynamic_attribute_associated_external_type",
+          "dynamic": {
+            "associated_external_type": {
+              "import": {
+                "path": "example.com/apisdk"
+              },
+              "type": "*apisdk.Type"
+            },
+            "optional_required": "optional"
+          }
+        },
+        {
+          "name": "dynamic_attribute_custom_type",
+          "dynamic": {
+            "optional_required": "optional",
+            "custom_type": {
+              "import": {
+                "path": "github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+              },
+              "type": "basetypes.DynamicType",
+              "value_type": "basetypes.DynamicValue"
+            }
+          }
+        },
+        {
+          "name": "dynamic_attribute_custom_type_import_alias",
+          "dynamic": {
+            "optional_required": "optional",
+            "custom_type": {
+              "import": {
+                "alias": "fwtype",
+                "path": "github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+              },
+              "type": "fwtype.DynamicType",
+              "value_type": "fwtype.DynamicValue"
+            }
+          }
+        },
+        {
+          "name": "dynamic_attribute_validators",
+          "dynamic": {
+            "optional_required": "optional",
+            "validators": [
+              {
+                "custom": {
+                  "imports": [
+                    {
+                      "path": "github.com/my_account/my_project/mydynamicvalidator"
+                    }
+                  ],
+                  "schema_definition": "mydynamicvalidator.Validate()"
+                }
+              }
+            ]
           }
         },
         {
@@ -2114,6 +2240,106 @@
                 "type": "*apisdk.Type"
               },
               "computed_optional_required": "optional"
+            }
+          },
+          {
+            "name": "dynamic_attribute",
+            "dynamic": {
+              "computed_optional_required": "computed"
+            }
+          },
+          {
+            "name": "dynamic_attribute_associated_external_type",
+            "dynamic": {
+              "associated_external_type": {
+                "import": {
+                  "path": "example.com/apisdk"
+                },
+                "type": "*apisdk.Type"
+              },
+              "computed_optional_required": "optional"
+            }
+          },
+          {
+            "name": "dynamic_attribute_custom_type",
+            "dynamic": {
+              "computed_optional_required": "computed",
+              "custom_type": {
+                "import": {
+                  "path": "github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+                },
+                "type": "basetypes.DynamicType",
+                "value_type": "basetypes.DynamicValue"
+              }
+            }
+          },
+          {
+            "name": "dynamic_attribute_custom_type_import_alias",
+            "dynamic": {
+              "computed_optional_required": "computed",
+              "custom_type": {
+                "import": {
+                  "alias": "fwtype",
+                  "path": "github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+                },
+                "type": "fwtype.DynamicType",
+                "value_type": "fwtype.DynamicValue"
+              }
+            }
+          },
+          {
+            "name": "dynamic_attribute_default",
+            "dynamic": {
+              "computed_optional_required": "optional",
+              "default": {
+                "custom": {
+                  "imports": [
+                    {
+                      "path": "github.com/hashicorp/terraform-plugin-framework/resource/schema/dynamicdefault"
+                    },
+                    {
+                      "path": "github.com/hashicorp/terraform-plugin-framework/types"
+                    }
+                  ],
+                  "schema_definition": "dynamicdefault.StaticValue(types.StringValue(\"example\"))"
+                }
+              }
+            }
+          },
+          {
+            "name": "dynamic_attribute_plan_modifiers",
+            "dynamic": {
+              "computed_optional_required": "computed",
+              "plan_modifiers": [
+                {
+                  "custom": {
+                    "imports": [
+                      {
+                        "path": "github.com/my_account/my_project/dynamicplanmodifier"
+                      }
+                    ],
+                    "schema_definition": "mydynamicplanmodifier.Modify()"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "name": "dynamic_attribute_validators",
+            "dynamic": {
+              "computed_optional_required": "computed",
+              "validators": [
+                {
+                  "custom": {
+                    "imports": [
+                      {
+                        "path": "github.com/my_account/my_project/mydynamicvalidator"
+                      }
+                    ],
+                    "schema_definition": "mydynamicvalidator.Validate()"
+                  }
+                }
+              ]
             }
           },
           {

--- a/spec/v0.1/example.json
+++ b/spec/v0.1/example.json
@@ -422,6 +422,18 @@
             }
           },
           {
+            "name": "object_attribute_attribute_types_dynamic",
+            "object": {
+              "computed_optional_required": "computed",
+              "attribute_types": [
+                {
+                  "name": "object_dynamic_attribute",
+                  "dynamic": {}
+                }
+              ]
+            }
+          },
+          {
             "name": "object_attribute_attribute_types_object_custom_type",
             "object": {
               "computed_optional_required": "computed",
@@ -1497,6 +1509,18 @@
               {
                 "name": "obj_string_attr",
                 "string": {}
+              }
+            ]
+          }
+        },
+        {
+          "name": "object_attribute_attribute_types_dynamic",
+          "object": {
+            "optional_required": "optional",
+            "attribute_types": [
+              {
+                "name": "object_dynamic_attribute",
+                "dynamic": {}
               }
             ]
           }
@@ -2709,6 +2733,18 @@
                 {
                   "name": "obj_string_attr",
                   "string": {}
+                }
+              ]
+            }
+          },
+          {
+            "name": "object_attribute_attribute_types_dynamic",
+            "object": {
+              "computed_optional_required": "computed",
+              "attribute_types": [
+                {
+                  "name": "object_dynamic_attribute",
+                  "dynamic": {}
                 }
               ]
             }

--- a/spec/v0.1/schema.json
+++ b/spec/v0.1/schema.json
@@ -96,6 +96,9 @@
             "$ref": "#/$defs/datasource_bool_attribute"
           },
           {
+            "$ref": "#/$defs/datasource_dynamic_attribute"
+          },
+          {
             "$ref": "#/$defs/datasource_float64_attribute"
           },
           {
@@ -191,6 +194,9 @@
         "oneOf": [
           {
             "$ref": "#/$defs/provider_bool_attribute"
+          },
+          {
+            "$ref": "#/$defs/provider_dynamic_attribute"
           },
           {
             "$ref": "#/$defs/provider_float64_attribute"
@@ -290,6 +296,9 @@
         "oneOf": [
           {
             "$ref": "#/$defs/resource_bool_attribute"
+          },
+          {
+            "$ref": "#/$defs/resource_dynamic_attribute"
           },
           {
             "$ref": "#/$defs/resource_float64_attribute"
@@ -748,6 +757,49 @@
       "required": [
         "name",
         "bool"
+      ]
+    },
+    "datasource_dynamic_attribute": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "$ref": "#/$defs/valid_identifier"
+        },
+        "dynamic": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "associated_external_type": {
+              "$ref": "#/$defs/schema_associated_external_type"
+            },
+            "computed_optional_required": {
+              "$ref": "#/$defs/schema_computed_optional_required"
+            },
+            "custom_type": {
+              "$ref": "#/$defs/schema_custom_type"
+            },
+            "deprecation_message": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "sensitive": {
+              "type": "boolean"
+            },
+            "validators": {
+              "$ref": "#/$defs/schema_dynamic_validators"
+            }
+          },
+          "required": [
+            "computed_optional_required"
+          ]
+        }
+      },
+      "required": [
+        "name",
+        "dynamic"
       ]
     },
     "datasource_float64_attribute": {
@@ -1480,6 +1532,49 @@
       "required": [
         "name",
         "bool"
+      ]
+    },
+    "provider_dynamic_attribute": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "$ref": "#/$defs/valid_identifier"
+        },
+        "dynamic": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "associated_external_type": {
+              "$ref": "#/$defs/schema_associated_external_type"
+            },
+            "custom_type": {
+              "$ref": "#/$defs/schema_custom_type"
+            },
+            "deprecation_message": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "optional_required": {
+              "$ref": "#/$defs/schema_optional_required"
+            },
+            "sensitive": {
+              "type": "boolean"
+            },
+            "validators": {
+              "$ref": "#/$defs/schema_dynamic_validators"
+            }
+          },
+          "required": [
+            "optional_required"
+          ]
+        }
+      },
+      "required": [
+        "name",
+        "dynamic"
       ]
     },
     "provider_float64_attribute": {
@@ -2224,6 +2319,55 @@
       "required": [
         "name",
         "bool"
+      ]
+    },
+    "resource_dynamic_attribute": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "$ref": "#/$defs/valid_identifier"
+        },
+        "dynamic": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "associated_external_type": {
+              "$ref": "#/$defs/schema_associated_external_type"
+            },
+            "computed_optional_required": {
+              "$ref": "#/$defs/schema_computed_optional_required"
+            },
+            "custom_type": {
+              "$ref": "#/$defs/schema_custom_type"
+            },
+            "default": {
+              "$ref": "#/$defs/schema_dynamic_default"
+            },
+            "deprecation_message": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "plan_modifiers": {
+              "$ref": "#/$defs/schema_dynamic_plan_modifiers"
+            },
+            "sensitive": {
+              "type": "boolean"
+            },
+            "validators": {
+              "$ref": "#/$defs/schema_dynamic_validators"
+            }
+          },
+          "required": [
+            "computed_optional_required"
+          ]
+        }
+      },
+      "required": [
+        "name",
+        "dynamic"
       ]
     },
     "resource_float64_attribute": {
@@ -3066,6 +3210,55 @@
       "required": [
         "schema_definition"
       ]
+    },
+    "schema_dynamic_default": {
+      "type": "object",
+      "properties": {
+        "custom": {
+          "$ref": "#/$defs/schema_custom_default"
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "custom"
+          ]
+        }
+      ]
+    },
+    "schema_dynamic_plan_modifier": {
+      "type": "object",
+      "properties": {
+        "custom": {
+          "$ref": "#/$defs/schema_custom_plan_modifier"
+        }
+      },
+      "required": [
+        "custom"
+      ]
+    },
+    "schema_dynamic_plan_modifiers": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/schema_dynamic_plan_modifier"
+      }
+    },
+    "schema_dynamic_validator": {
+      "type": "object",
+      "properties": {
+        "custom": {
+          "$ref": "#/$defs/schema_custom_validator"
+        }
+      },
+      "required": [
+        "custom"
+      ]
+    },
+    "schema_dynamic_validators": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/schema_dynamic_validator"
+      }
     },
     "schema_float64_default": {
       "type": "object",

--- a/spec/v0.1/schema.json
+++ b/spec/v0.1/schema.json
@@ -407,6 +407,15 @@
         }
       }
     },
+    "schema_dynamic_type": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "custom_type": {
+          "$ref": "#/$defs/schema_custom_type"
+        }
+      }
+    },
     "schema_element_type": {
       "type": "object",
       "additionalProperties": false,
@@ -561,6 +570,9 @@
         "bool": {
           "$ref": "#/$defs/schema_bool_type"
         },
+        "dynamic": {
+          "$ref": "#/$defs/schema_dynamic_type"
+        },
         "float64": {
           "$ref": "#/$defs/schema_float64_type"
         },
@@ -593,6 +605,11 @@
         {
           "required": [
             "bool"
+          ]
+        },
+        {
+          "required": [
+            "dynamic"
           ]
         },
         {


### PR DESCRIPTION
Closes #94

Adds initial support for dynamic attributes in data source, provider, and resource schemas.