### PR TITLE
Chore: golangci-lint fixes

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,13 +1,13 @@
 issues:
-  max-per-linter: 0
+  max-issues-per-linter: 0
   max-same-issues: 0
 
 linters:
   disable-all: true
   enable:
+    - copyloopvar
     - durationcheck
     - errcheck
-    - exportloopref
     - forcetypeassert
     - gofmt
     - gosimple
@@ -19,7 +19,7 @@ linters:
     - paralleltest
     - predeclared
     - staticcheck
-    - tenv
     - unconvert
     - unparam
     - unused
+    - usetesting

--- a/datasource/attribute_test.go
+++ b/datasource/attribute_test.go
@@ -272,7 +272,6 @@ func TestAttributes_Validate(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/provider/attribute_test.go
+++ b/provider/attribute_test.go
@@ -272,7 +272,6 @@ func TestAttributes_Validate(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/resource/attribute_test.go
+++ b/resource/attribute_test.go
@@ -272,7 +272,6 @@ func TestAttributes_Validate(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/schema/associated_external_type_test.go
+++ b/schema/associated_external_type_test.go
@@ -42,7 +42,6 @@ func TestAssociatedExternalType_HasImport(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -188,7 +187,6 @@ func TestAssociatedExternalType_Equal(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/schema/bool_default_test.go
+++ b/schema/bool_default_test.go
@@ -52,7 +52,6 @@ func TestBoolDefault_Equal(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/schema/bool_plan_modifier_test.go
+++ b/schema/bool_plan_modifier_test.go
@@ -124,7 +124,6 @@ func TestBoolPlanModifiers_Equal(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/schema/bool_validator_test.go
+++ b/schema/bool_validator_test.go
@@ -124,7 +124,6 @@ func TestBoolValidators_Equal(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/schema/custom_default_test.go
+++ b/schema/custom_default_test.go
@@ -65,7 +65,6 @@ func TestCustomDefault_HasImport(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -225,7 +224,6 @@ func TestCustomDefault_Equal(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/schema/custom_plan_modifier_test.go
+++ b/schema/custom_plan_modifier_test.go
@@ -65,7 +65,6 @@ func TestCustomPlanModifier_HasImport(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -225,7 +224,6 @@ func TestCustomPlanModifier_Equal(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -280,7 +278,6 @@ func TestCustomPlanModifiers_Sort(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/schema/custom_type_test.go
+++ b/schema/custom_type_test.go
@@ -42,7 +42,6 @@ func TestCustomType_HasImport(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -213,7 +212,6 @@ func TestCustomType_Equal(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/schema/custom_validator_test.go
+++ b/schema/custom_validator_test.go
@@ -65,7 +65,6 @@ func TestCustomValidator_HasImport(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -225,7 +224,6 @@ func TestCustomValidator_Equal(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -280,7 +278,6 @@ func TestCustomValidators_Sort(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/schema/dynamic_default_test.go
+++ b/schema/dynamic_default_test.go
@@ -29,7 +29,6 @@ func TestDynamicDefault_Equal(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/schema/dynamic_plan_modifier_test.go
+++ b/schema/dynamic_plan_modifier_test.go
@@ -124,7 +124,6 @@ func TestDynamicPlanModifiers_Equal(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/schema/dynamic_validator_test.go
+++ b/schema/dynamic_validator_test.go
@@ -124,7 +124,6 @@ func TestDynamicValidators_Equal(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/schema/element_type_test.go
+++ b/schema/element_type_test.go
@@ -141,7 +141,6 @@ func TestElementType_Equal(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/schema/float64_default_test.go
+++ b/schema/float64_default_test.go
@@ -52,7 +52,6 @@ func TestFloat64Default_Equal(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/schema/float64_plan_modifier_test.go
+++ b/schema/float64_plan_modifier_test.go
@@ -124,7 +124,6 @@ func TestFloat64PlanModifiers_Equal(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/schema/float64_validator_test.go
+++ b/schema/float64_validator_test.go
@@ -124,7 +124,6 @@ func TestFloat64Validators_Equal(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/schema/int64_default_test.go
+++ b/schema/int64_default_test.go
@@ -52,7 +52,6 @@ func TestInt64Default_Equal(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/schema/int64_plan_modifier_test.go
+++ b/schema/int64_plan_modifier_test.go
@@ -124,7 +124,6 @@ func TestInt64PlanModifiers_Equal(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/schema/int64_validator_test.go
+++ b/schema/int64_validator_test.go
@@ -124,7 +124,6 @@ func TestInt64Validators_Equal(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/schema/list_default_test.go
+++ b/schema/list_default_test.go
@@ -29,7 +29,6 @@ func TestListDefault_Equal(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/schema/list_plan_modifier_test.go
+++ b/schema/list_plan_modifier_test.go
@@ -124,7 +124,6 @@ func TestListPlanModifiers_Equal(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/schema/list_validator_test.go
+++ b/schema/list_validator_test.go
@@ -124,7 +124,6 @@ func TestListValidators_Equal(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/schema/map_default_test.go
+++ b/schema/map_default_test.go
@@ -29,7 +29,6 @@ func TestMapDefault_Equal(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/schema/map_plan_modifier_test.go
+++ b/schema/map_plan_modifier_test.go
@@ -124,7 +124,6 @@ func TestMapPlanModifiers_Equal(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/schema/map_validator_test.go
+++ b/schema/map_validator_test.go
@@ -124,7 +124,6 @@ func TestMapValidators_Equal(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/schema/number_default_test.go
+++ b/schema/number_default_test.go
@@ -29,7 +29,6 @@ func TestNumberDefault_Equal(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/schema/number_plan_modifier_test.go
+++ b/schema/number_plan_modifier_test.go
@@ -124,7 +124,6 @@ func TestNumberPlanModifiers_Equal(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/schema/number_validator_test.go
+++ b/schema/number_validator_test.go
@@ -124,7 +124,6 @@ func TestNumberValidators_Equal(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/schema/object_attribute_type_test.go
+++ b/schema/object_attribute_type_test.go
@@ -45,7 +45,6 @@ func TestObjectAttributeTypes_Equal(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -212,7 +211,6 @@ func TestObjectAttributeType_Equal(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/schema/object_default_test.go
+++ b/schema/object_default_test.go
@@ -29,7 +29,6 @@ func TestObjectDefault_Equal(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/schema/object_plan_modifier_test.go
+++ b/schema/object_plan_modifier_test.go
@@ -124,7 +124,6 @@ func TestObjectPlanModifiers_Equal(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/schema/object_type_test.go
+++ b/schema/object_type_test.go
@@ -82,7 +82,6 @@ func TestObjectType_Equal(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/schema/object_validator_test.go
+++ b/schema/object_validator_test.go
@@ -124,7 +124,6 @@ func TestObjectValidators_Equal(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/schema/set_default_test.go
+++ b/schema/set_default_test.go
@@ -29,7 +29,6 @@ func TestSetDefault_Equal(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/schema/set_plan_modifier_test.go
+++ b/schema/set_plan_modifier_test.go
@@ -124,7 +124,6 @@ func TestSetPlanModifiers_Equal(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/schema/set_validator_test.go
+++ b/schema/set_validator_test.go
@@ -124,7 +124,6 @@ func TestSetValidators_Equal(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/schema/string_default_test.go
+++ b/schema/string_default_test.go
@@ -52,7 +52,6 @@ func TestStringDefault_Equal(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/schema/string_plan_modifier_test.go
+++ b/schema/string_plan_modifier_test.go
@@ -124,7 +124,6 @@ func TestStringPlanModifiers_Equal(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/schema/string_validator_test.go
+++ b/schema/string_validator_test.go
@@ -124,7 +124,6 @@ func TestStringValidators_Equal(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/spec/specification_test.go
+++ b/spec/specification_test.go
@@ -35,7 +35,6 @@ func TestSpecification_JSONMarshal(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -3523,7 +3522,6 @@ func TestSpecification_JSONUnmarshal_Version0_1(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -4340,7 +4338,6 @@ func TestSpecification_Validate_DataSources(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -5068,7 +5065,6 @@ func TestSpecification_Validate_Provider(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -5879,7 +5875,6 @@ func TestSpecification_Validate_Resources(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -9363,7 +9358,6 @@ func TestSpecification_Generate_Version0_1(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/spec/validate_test.go
+++ b/spec/validate_test.go
@@ -1271,7 +1271,6 @@ func TestValidate_Version0_1(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		name, testCase := name, testCase
 
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()


### PR DESCRIPTION
- Replace `max-per-linter` with `max-issues-per-linters`
- Replace `exportloopref` linter with `copyloopvar`
- Replace `tenv` linter with `usetesting`