### PR TITLE
Add write_only to resource attributes

### DIFF
--- a/resource/attribute.go
+++ b/resource/attribute.go
@@ -143,6 +143,10 @@ type BoolAttribute struct {
 	// be considered sensitive data.
 	Sensitive *bool `json:"sensitive,omitempty"`
 
+	// WriteOnly indicates that Terraform will not store
+	// this attribute value in the plan or state artifacts.
+	WriteOnly *bool `json:"write_only,omitempty"`
+
 	// Validators define types and functions that provide validation
 	// functionality for the block.
 	Validators schema.BoolValidators `json:"validators,omitempty"`
@@ -178,6 +182,10 @@ type DynamicAttribute struct {
 	// Sensitive indicates whether the value of the attribute should
 	// be considered sensitive data.
 	Sensitive *bool `json:"sensitive,omitempty"`
+
+	// WriteOnly indicates that Terraform will not store
+	// this attribute value in the plan or state artifacts.
+	WriteOnly *bool `json:"write_only,omitempty"`
 
 	// Validators define types and functions that provide validation
 	// functionality for the block.
@@ -217,6 +225,10 @@ type Float64Attribute struct {
 	// Sensitive indicates whether the value of the attribute should
 	// be considered sensitive data.
 	Sensitive *bool `json:"sensitive,omitempty"`
+
+	// WriteOnly indicates that Terraform will not store
+	// this attribute value in the plan or state artifacts.
+	WriteOnly *bool `json:"write_only,omitempty"`
 
 	// Validators define types and functions that provide validation
 	// functionality for the block.
@@ -258,6 +270,10 @@ type Int64Attribute struct {
 	// be considered sensitive data.
 	Sensitive *bool `json:"sensitive,omitempty"`
 
+	// WriteOnly indicates that Terraform will not store
+	// this attribute value in the plan or state artifacts.
+	WriteOnly *bool `json:"write_only,omitempty"`
+
 	// Validators define types and functions that provide validation
 	// functionality for the block.
 	Validators schema.Int64Validators `json:"validators,omitempty"`
@@ -298,6 +314,10 @@ type ListAttribute struct {
 	// be considered sensitive data.
 	Sensitive *bool `json:"sensitive,omitempty"`
 
+	// WriteOnly indicates that Terraform will not store
+	// this attribute value in the plan or state artifacts.
+	WriteOnly *bool `json:"write_only,omitempty"`
+
 	// Validators define types and functions that provide validation
 	// functionality for the block.
 	Validators schema.ListValidators `json:"validators,omitempty"`
@@ -334,6 +354,10 @@ type ListNestedAttribute struct {
 	// Sensitive indicates whether the value of the attribute should
 	// be considered sensitive data.
 	Sensitive *bool `json:"sensitive,omitempty"`
+
+	// WriteOnly indicates that Terraform will not store
+	// this attribute value in the plan or state artifacts.
+	WriteOnly *bool `json:"write_only,omitempty"`
 
 	// Validators define types and functions that provide validation
 	// functionality for the block.
@@ -375,6 +399,10 @@ type MapAttribute struct {
 	// be considered sensitive data.
 	Sensitive *bool `json:"sensitive,omitempty"`
 
+	// WriteOnly indicates that Terraform will not store
+	// this attribute value in the plan or state artifacts.
+	WriteOnly *bool `json:"write_only,omitempty"`
+
 	// Validators define types and functions that provide validation
 	// functionality for the block.
 	Validators schema.MapValidators `json:"validators,omitempty"`
@@ -411,6 +439,10 @@ type MapNestedAttribute struct {
 	// Sensitive indicates whether the value of the attribute should
 	// be considered sensitive data.
 	Sensitive *bool `json:"sensitive,omitempty"`
+
+	// WriteOnly indicates that Terraform will not store
+	// this attribute value in the plan or state artifacts.
+	WriteOnly *bool `json:"write_only,omitempty"`
 
 	// Validators define types and functions that provide validation
 	// functionality for the block.
@@ -452,6 +484,10 @@ type NumberAttribute struct {
 	// be considered sensitive data.
 	Sensitive *bool `json:"sensitive,omitempty"`
 
+	// WriteOnly indicates that Terraform will not store
+	// this attribute value in the plan or state artifacts.
+	WriteOnly *bool `json:"write_only,omitempty"`
+
 	// Validators define types and functions that provide validation
 	// functionality for the block.
 	Validators schema.NumberValidators `json:"validators,omitempty"`
@@ -491,6 +527,10 @@ type ObjectAttribute struct {
 	// Sensitive indicates whether the value of the attribute should
 	// be considered sensitive data.
 	Sensitive *bool `json:"sensitive,omitempty"`
+
+	// WriteOnly indicates that Terraform will not store
+	// this attribute value in the plan or state artifacts.
+	WriteOnly *bool `json:"write_only,omitempty"`
 
 	// Validators define types and functions that provide validation
 	// functionality for the block.
@@ -532,6 +572,10 @@ type SetAttribute struct {
 	// be considered sensitive data.
 	Sensitive *bool `json:"sensitive,omitempty"`
 
+	// WriteOnly indicates that Terraform will not store
+	// this attribute value in the plan or state artifacts.
+	WriteOnly *bool `json:"write_only,omitempty"`
+
 	// Validators define types and functions that provide validation
 	// functionality for the block.
 	Validators schema.SetValidators `json:"validators,omitempty"`
@@ -568,6 +612,10 @@ type SetNestedAttribute struct {
 	// Sensitive indicates whether the value of the attribute should
 	// be considered sensitive data.
 	Sensitive *bool `json:"sensitive,omitempty"`
+
+	// WriteOnly indicates that Terraform will not store
+	// this attribute value in the plan or state artifacts.
+	WriteOnly *bool `json:"write_only,omitempty"`
 
 	// Validators define types and functions that provide validation
 	// functionality for the block.
@@ -609,6 +657,10 @@ type SingleNestedAttribute struct {
 	// be considered sensitive data.
 	Sensitive *bool `json:"sensitive,omitempty"`
 
+	// WriteOnly indicates that Terraform will not store
+	// this attribute value in the plan or state artifacts.
+	WriteOnly *bool `json:"write_only,omitempty"`
+
 	// Validators define types and functions that provide validation
 	// functionality for the block.
 	Validators schema.ObjectValidators `json:"validators,omitempty"`
@@ -644,6 +696,10 @@ type StringAttribute struct {
 	// Sensitive indicates whether the value of the attribute should
 	// be considered sensitive data.
 	Sensitive *bool `json:"sensitive,omitempty"`
+
+	// WriteOnly indicates that Terraform will not store
+	// this attribute value in the plan or state artifacts.
+	WriteOnly *bool `json:"write_only,omitempty"`
 
 	// Validators define types and functions that provide validation
 	// functionality for the block.

--- a/spec/v0.1/schema.json
+++ b/spec/v0.1/schema.json
@@ -2324,6 +2324,9 @@
             "sensitive": {
               "type": "boolean"
             },
+            "write_only": {
+              "type": "boolean"
+            },
             "validators": {
               "$ref": "#/$defs/schema_bool_validators"
             }
@@ -2371,6 +2374,9 @@
               "$ref": "#/$defs/schema_dynamic_plan_modifiers"
             },
             "sensitive": {
+              "type": "boolean"
+            },
+            "write_only": {
               "type": "boolean"
             },
             "validators": {
@@ -2422,6 +2428,9 @@
             "sensitive": {
               "type": "boolean"
             },
+            "write_only": {
+              "type": "boolean"
+            },
             "validators": {
               "$ref": "#/$defs/schema_float64_validators"
             }
@@ -2469,6 +2478,9 @@
               "$ref": "#/$defs/schema_int64_plan_modifiers"
             },
             "sensitive": {
+              "type": "boolean"
+            },
+            "write_only": {
               "type": "boolean"
             },
             "validators": {
@@ -2523,6 +2535,9 @@
             "sensitive": {
               "type": "boolean"
             },
+            "write_only": {
+              "type": "boolean"
+            },
             "validators": {
               "$ref": "#/$defs/schema_list_validators"
             }
@@ -2571,6 +2586,9 @@
               "$ref": "#/$defs/schema_list_plan_modifiers"
             },
             "sensitive": {
+              "type": "boolean"
+            },
+            "write_only": {
               "type": "boolean"
             },
             "validators": {
@@ -2669,6 +2687,9 @@
             "sensitive": {
               "type": "boolean"
             },
+            "write_only": {
+              "type": "boolean"
+            },
             "validators": {
               "$ref": "#/$defs/schema_map_validators"
             }
@@ -2717,6 +2738,9 @@
               "$ref": "#/$defs/schema_map_plan_modifiers"
             },
             "sensitive": {
+              "type": "boolean"
+            },
+            "write_only": {
               "type": "boolean"
             },
             "validators": {
@@ -2769,6 +2793,9 @@
             "sensitive": {
               "type": "boolean"
             },
+            "write_only": {
+              "type": "boolean"
+            },
             "validators": {
               "$ref": "#/$defs/schema_number_validators"
             }
@@ -2819,6 +2846,9 @@
               "$ref": "#/$defs/schema_object_plan_modifiers"
             },
             "sensitive": {
+              "type": "boolean"
+            },
+            "write_only": {
               "type": "boolean"
             },
             "validators": {
@@ -2874,6 +2904,9 @@
             "sensitive": {
               "type": "boolean"
             },
+            "write_only": {
+              "type": "boolean"
+            },
             "validators": {
               "$ref": "#/$defs/schema_set_validators"
             }
@@ -2922,6 +2955,9 @@
               "$ref": "#/$defs/schema_set_plan_modifiers"
             },
             "sensitive": {
+              "type": "boolean"
+            },
+            "write_only": {
               "type": "boolean"
             },
             "validators": {
@@ -3020,6 +3056,9 @@
             "sensitive": {
               "type": "boolean"
             },
+            "write_only": {
+              "type": "boolean"
+            },
             "validators": {
               "$ref": "#/$defs/schema_object_validators"
             }
@@ -3113,6 +3152,9 @@
               "$ref": "#/$defs/schema_string_plan_modifiers"
             },
             "sensitive": {
+              "type": "boolean"
+            },
+            "write_only": {
               "type": "boolean"
             },
             "validators": {


### PR DESCRIPTION
Supports adding WriteOnly to resource schemas, eg:

```
"password": schema.StringAttribute{
	Required:            true,
	WriteOnly:           true, <- write_only
	Sensitive:           true,
	Description:         "Super secret password",
},
```